### PR TITLE
Upgrade to intervention/image v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.5']
+        php-version: ['8.3', '8.5']
 
     steps:
     - uses: actions/checkout@v5
@@ -35,14 +35,14 @@ jobs:
 
     - name: Run PHPUnit
       run: |
-        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.3' ]]; then
           vendor/bin/phpunit --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
         fi
 
     - name: Code Coverage Report
-      if: success() && matrix.php-version == '8.1'
+      if: success() && matrix.php-version == '8.3'
       uses: codecov/codecov-action@v3
 
   cs-stan:
@@ -55,7 +55,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.1'
+        php-version: '8.3'
         extensions: mbstring, json, fileinfo
         coverage: none
         tools: pecl

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "ext-json": "*",
-        "intervention/image": "^3.2.0",
+        "intervention/image": "^4.0",
         "spatie/image-optimizer": "^1.2.0"
     },
     "require-dev": {

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -15,6 +15,7 @@
 namespace PhpCollective\Infrastructure\Storage\Processor\Image;
 
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use InvalidArgumentException;
 use League\Flysystem\Config;
@@ -246,7 +247,7 @@ class ImageProcessor implements ProcessorInterface
                 continue;
             }
 
-            $this->image = $this->imageManager->read($tempFile);
+            $this->image = $this->imageManager->decodePath($tempFile);
             $operations = new Operations($this->image);
 
             // Apply the operations
@@ -259,12 +260,16 @@ class ImageProcessor implements ProcessorInterface
             if (isset($data['optimize']) && $data['optimize'] === true) {
                 $this->optimizeAndStore($file, $path);
             } else {
-                $encoded = $this->image->encodeByExtension($file->extension(), $this->quality);
+                $encoded = $this->encodeImage($file->extension());
+                $stream = openFile('php://temp', 'rb+');
+                fwrite($stream, (string)$encoded);
+                rewind($stream);
                 $storage->writeStream(
                     $path,
-                    $encoded->toFilePointer(),
+                    $stream,
                     new Config(),
                 );
+                fclose($stream);
             }
 
             $data['path'] = $path;
@@ -283,6 +288,38 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
+     * Encodes the current image using the given file extension. Quality is only
+     * passed to encoders that accept it (jpg/jpeg/webp/avif/heic/tiff); for
+     * formats like png and gif passing it would trigger an unknown-named-arg
+     * error in intervention/image v4.
+     *
+     * @param string|null $extension File extension
+     *
+     * @throws \InvalidArgumentException If extension is empty
+     *
+     * @return \Intervention\Image\Interfaces\EncodedImageInterface
+     */
+    protected function encodeImage(?string $extension): EncodedImageInterface
+    {
+        if ($extension === null || $extension === '') {
+            throw new InvalidArgumentException('Cannot encode image without a file extension');
+        }
+
+        $extension = strtolower($extension);
+        $supportsQuality = in_array(
+            $extension,
+            ['jpg', 'jpeg', 'webp', 'avif', 'heic', 'tiff'],
+            true,
+        );
+
+        if ($supportsQuality) {
+            return $this->image->encodeUsingFileExtension($extension, quality: $this->quality);
+        }
+
+        return $this->image->encodeUsingFileExtension($extension);
+    }
+
+    /**
      * @param \PhpCollective\Infrastructure\Storage\FileInterface $file File
      * @param string $path Path
      *
@@ -298,7 +335,7 @@ class ImageProcessor implements ProcessorInterface
         $optimizerOutput = TemporaryFile::create();
 
         // Encode the image with the proper format and write to temp file
-        $encoded = $this->image->encodeByExtension($file->extension(), $this->quality);
+        $encoded = $this->encodeImage($file->extension());
         file_put_contents($optimizerTempFile, (string)$encoded);
 
         // Optimize it and write it to another file

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -36,13 +36,48 @@ class ImageProcessor implements ProcessorInterface
     use OptimizerTrait;
 
     /**
+     * Default quality used when no per-format quality has been configured.
+     *
+     * @var int
+     */
+    public const DEFAULT_QUALITY = 90;
+
+    /**
+     * File extensions whose encoder accepts a `quality` named argument under
+     * intervention/image v4. Encoders for png/gif/bmp/ico do not accept it
+     * and would throw on an unknown named argument.
+     *
+     * @var array<int, string>
+     */
+    protected const QUALITY_AWARE_EXTENSIONS = [
+        'jpg',
+        'jpeg',
+        'pjpg',
+        'pjpeg',
+        'webp',
+        'avif',
+        'heic',
+        'heif',
+        'tif',
+        'tiff',
+        'jp2',
+        'j2k',
+    ];
+
+    /**
      * @var array<int, string>
      */
     protected array $mimeTypes = [
+        'image/avif',
+        'image/bmp',
         'image/gif',
-        'image/jpg',
+        'image/heic',
+        'image/heif',
         'image/jpeg',
+        'image/jpg',
         'image/png',
+        'image/tiff',
+        'image/webp',
     ];
 
     /**
@@ -76,11 +111,27 @@ class ImageProcessor implements ProcessorInterface
     protected ImageInterface $image;
 
     /**
-     * Quality setting for writing images
+     * Default quality used when no per-format override is configured.
      *
      * @var int
      */
-    protected int $quality = 90;
+    protected int $defaultQuality = self::DEFAULT_QUALITY;
+
+    /**
+     * Per-extension quality overrides, keyed by lower-cased file extension.
+     *
+     * @var array<string, int>
+     */
+    protected array $qualityMap = [];
+
+    /**
+     * Whether to strip EXIF/metadata when encoding output. Defaults to true
+     * for privacy and smaller file sizes; disable if downstream consumers
+     * rely on metadata such as orientation, ICC profile or copyright tags.
+     *
+     * @var bool
+     */
+    protected bool $stripExif = true;
 
     /**
      * @param \PhpCollective\Infrastructure\Storage\FileStorageInterface $storageHandler File Storage Handler
@@ -113,13 +164,66 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
-     * @param int $quality Quality
+     * Sets the encoder quality. Pass an int (1-100) to apply a single value
+     * to every quality-aware format, or an array keyed by extension (e.g.
+     * `['webp' => 80, 'jpg' => 90]`) to use different qualities per format.
+     *
+     * @param array<string, int>|int $quality Quality
      *
      * @throws \InvalidArgumentException
      *
      * @return $this
      */
-    public function setQuality(int $quality)
+    public function setQuality(int|array $quality)
+    {
+        if (is_int($quality)) {
+            $this->assertValidQuality($quality);
+            $this->defaultQuality = $quality;
+            $this->qualityMap = [];
+
+            return $this;
+        }
+
+        $map = [];
+        foreach ($quality as $extension => $value) {
+            if ($extension === '') {
+                throw new InvalidArgumentException(
+                    'Quality map keys must be non-empty extension strings',
+                );
+            }
+            $intValue = (int)$value;
+            $this->assertValidQuality($intValue);
+            $map[strtolower($extension)] = $intValue;
+        }
+
+        $this->qualityMap = $map;
+
+        return $this;
+    }
+
+    /**
+     * Toggles whether EXIF/metadata is stripped from encoded output. Only
+     * affects encoders that support it (jpg/jpeg/webp/avif/heic/tiff/jp2).
+     *
+     * @param bool $strip Whether to strip metadata
+     *
+     * @return $this
+     */
+    public function setStripExif(bool $strip)
+    {
+        $this->stripExif = $strip;
+
+        return $this;
+    }
+
+    /**
+     * @param int $quality Quality
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function assertValidQuality(int $quality): void
     {
         if ($quality > 100 || $quality <= 0) {
             throw new InvalidArgumentException(sprintf(
@@ -127,10 +231,16 @@ class ImageProcessor implements ProcessorInterface
                 (string)$quality,
             ));
         }
+    }
 
-        $this->quality = $quality;
-
-        return $this;
+    /**
+     * @param string $extension File extension (lower-case)
+     *
+     * @return int
+     */
+    protected function qualityFor(string $extension): int
+    {
+        return $this->qualityMap[$extension] ?? $this->defaultQuality;
     }
 
     /**
@@ -255,12 +365,13 @@ class ImageProcessor implements ProcessorInterface
                 $operations->{$operation}($arguments);
             }
 
-            $path = $this->pathBuilder->pathForVariant($file, $variant);
+            $extension = $operations->getOutputFormat() ?? $file->extension();
+            $path = $this->pathForVariant($file, $variant, $operations->getOutputFormat());
 
             if (isset($data['optimize']) && $data['optimize'] === true) {
-                $this->optimizeAndStore($file, $path);
+                $this->optimizeAndStore($file, $path, $extension);
             } else {
-                $encoded = $this->encodeImage($file->extension());
+                $encoded = $this->encodeImage($extension);
                 $stream = openFile('php://temp', 'rb+');
                 fwrite($stream, (string)$encoded);
                 rewind($stream);
@@ -288,10 +399,32 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
-     * Encodes the current image using the given file extension. Quality is only
-     * passed to encoders that accept it (jpg/jpeg/webp/avif/heic/tiff); for
-     * formats like png and gif passing it would trigger an unknown-named-arg
-     * error in intervention/image v4.
+     * Returns the variant's storage path. When a `convert` operation requested
+     * a different output format the source extension in the built path is
+     * swapped for the requested one so the stored file's extension matches
+     * its actual encoding.
+     *
+     * @param \PhpCollective\Infrastructure\Storage\FileInterface $file File
+     * @param string $variant Variant name
+     * @param string|null $outputFormat Override extension or null
+     *
+     * @return string
+     */
+    protected function pathForVariant(FileInterface $file, string $variant, ?string $outputFormat): string
+    {
+        $path = $this->pathBuilder->pathForVariant($file, $variant);
+        if ($outputFormat === null || $outputFormat === '') {
+            return $path;
+        }
+
+        return preg_replace('/\.[^.\/\\\]+$/', '.' . $outputFormat, $path) ?? $path;
+    }
+
+    /**
+     * Encodes the current image using the given file extension. `quality` and
+     * `strip` are only forwarded to encoders that accept them; for png/gif/bmp
+     * passing them would trigger an unknown-named-argument error in
+     * intervention/image v4.
      *
      * @param string|null $extension File extension
      *
@@ -306,14 +439,12 @@ class ImageProcessor implements ProcessorInterface
         }
 
         $extension = strtolower($extension);
-        $supportsQuality = in_array(
-            $extension,
-            ['jpg', 'jpeg', 'webp', 'avif', 'heic', 'tiff'],
-            true,
-        );
-
-        if ($supportsQuality) {
-            return $this->image->encodeUsingFileExtension($extension, quality: $this->quality);
+        if (in_array($extension, self::QUALITY_AWARE_EXTENSIONS, true)) {
+            return $this->image->encodeUsingFileExtension(
+                $extension,
+                quality: $this->qualityFor($extension),
+                strip: $this->stripExif,
+            );
         }
 
         return $this->image->encodeUsingFileExtension($extension);
@@ -322,10 +453,11 @@ class ImageProcessor implements ProcessorInterface
     /**
      * @param \PhpCollective\Infrastructure\Storage\FileInterface $file File
      * @param string $path Path
+     * @param string|null $extension Output file extension
      *
      * @return void
      */
-    protected function optimizeAndStore(FileInterface $file, string $path): void
+    protected function optimizeAndStore(FileInterface $file, string $path, ?string $extension = null): void
     {
         $storage = $this->storageHandler->getStorage($file->storage());
 
@@ -335,7 +467,7 @@ class ImageProcessor implements ProcessorInterface
         $optimizerOutput = TemporaryFile::create();
 
         // Encode the image with the proper format and write to temp file
-        $encoded = $this->encodeImage($file->extension());
+        $encoded = $this->encodeImage($extension ?? $file->extension());
         file_put_contents($optimizerTempFile, (string)$encoded);
 
         // Optimize it and write it to another file

--- a/src/ImageVariant.php
+++ b/src/ImageVariant.php
@@ -288,6 +288,191 @@ class ImageVariant extends Variant
     }
 
     /**
+     * Auto-rotates the image based on EXIF orientation. Best placed first
+     * to normalise camera uploads before further operations.
+     *
+     * @return $this
+     */
+    public function orient()
+    {
+        $this->operations['orient'] = [];
+
+        return $this;
+    }
+
+    /**
+     * @param int $level Brightness level, -100 to 100
+     *
+     * @return $this
+     */
+    public function brightness(int $level)
+    {
+        $this->operations['brightness'] = ['level' => $level];
+
+        return $this;
+    }
+
+    /**
+     * @param int $level Contrast level, -100 to 100
+     *
+     * @return $this
+     */
+    public function contrast(int $level)
+    {
+        $this->operations['contrast'] = ['level' => $level];
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function grayscale()
+    {
+        $this->operations['grayscale'] = [];
+
+        return $this;
+    }
+
+    /**
+     * @param int $red Red shift, -100 to 100
+     * @param int $green Green shift, -100 to 100
+     * @param int $blue Blue shift, -100 to 100
+     *
+     * @return $this
+     */
+    public function colorize(int $red = 0, int $green = 0, int $blue = 0)
+    {
+        $this->operations['colorize'] = [
+            'red' => $red,
+            'green' => $green,
+            'blue' => $blue,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @param int $level Blur level, 0 to 100
+     *
+     * @return $this
+     */
+    public function blur(int $level = 5)
+    {
+        $this->operations['blur'] = ['level' => $level];
+
+        return $this;
+    }
+
+    /**
+     * @param int $size Pixel block size
+     *
+     * @return $this
+     */
+    public function pixelate(int $size)
+    {
+        $this->operations['pixelate'] = ['size' => $size];
+
+        return $this;
+    }
+
+    /**
+     * @param int $tolerance Color tolerance for trimming, 0 to 100
+     *
+     * @return $this
+     */
+    public function trim(int $tolerance = 0)
+    {
+        $this->operations['trim'] = ['tolerance' => $tolerance];
+
+        return $this;
+    }
+
+    /**
+     * @param int $width Canvas width
+     * @param int $height Canvas height
+     * @param string|null $background Background color (hex or named)
+     * @param string $position Alignment of the original image
+     *
+     * @return $this
+     */
+    public function resizeCanvas(
+        int $width,
+        int $height,
+        ?string $background = null,
+        string $position = 'center',
+    ) {
+        $this->operations['resizeCanvas'] = [
+            'width' => $width,
+            'height' => $height,
+            'background' => $background,
+            'position' => $position,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @param int $amount Padding in pixels (added on each side)
+     * @param string|null $background Background color
+     *
+     * @return $this
+     */
+    public function padding(int $amount, ?string $background = null)
+    {
+        $this->operations['padding'] = [
+            'amount' => $amount,
+            'background' => $background,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Inserts a watermark or overlay on top of the image.
+     *
+     * @param string $image Path to overlay image
+     * @param string $position Alignment, e.g. 'bottom-right'
+     * @param int $x Horizontal offset from alignment position
+     * @param int $y Vertical offset from alignment position
+     * @param float $opacity Opacity, 0.0 to 1.0
+     *
+     * @return $this
+     */
+    public function place(
+        string $image,
+        string $position = 'bottom-center',
+        int $x = 0,
+        int $y = 0,
+        float $opacity = 1.0,
+    ) {
+        $this->operations['place'] = [
+            'image' => $image,
+            'position' => $position,
+            'x' => $x,
+            'y' => $y,
+            'opacity' => $opacity,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Re-encode the variant in a different format than the source. Use this
+     * to e.g. generate WebP variants from JPEG uploads.
+     *
+     * @param string $format Target file extension, e.g. 'webp'
+     *
+     * @return $this
+     */
+    public function convert(string $format)
+    {
+        $this->operations['convert'] = ['format' => $format];
+
+        return $this;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -77,11 +77,28 @@ class Operations
     protected ImageInterface $image;
 
     /**
+     * Output format requested via the `convert` operation. When set the
+     * processor will encode the variant using this extension instead of the
+     * source file's extension.
+     *
+     * @var string|null
+     */
+    protected ?string $outputFormat = null;
+
+    /**
      * @param \Intervention\Image\Interfaces\ImageInterface $image Image
      */
     public function __construct(ImageInterface $image)
     {
         $this->image = $image;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOutputFormat(): ?string
+    {
+        return $this->outputFormat;
     }
 
     /**
@@ -311,6 +328,239 @@ class Operations
         }
 
         $this->image->sharpen((int)$arguments['amount']);
+    }
+
+    /**
+     * Auto-rotates the image based on EXIF orientation data and clears the
+     * EXIF orientation tag. Useful as the first operation to normalise camera
+     * uploads before further processing.
+     *
+     * @return void
+     */
+    public function orient(): void
+    {
+        $this->image->orient();
+    }
+
+    /**
+     * Adjusts the image brightness. Level ranges from -100 (darker) to
+     * 100 (brighter).
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function brightness(array $arguments): void
+    {
+        if (!isset($arguments['level'])) {
+            throw new InvalidArgumentException('Missing level');
+        }
+
+        $this->image->brightness((int)$arguments['level']);
+    }
+
+    /**
+     * Adjusts the image contrast. Level ranges from -100 (less) to
+     * 100 (more).
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function contrast(array $arguments): void
+    {
+        if (!isset($arguments['level'])) {
+            throw new InvalidArgumentException('Missing level');
+        }
+
+        $this->image->contrast((int)$arguments['level']);
+    }
+
+    /**
+     * Converts the image to grayscale.
+     *
+     * @return void
+     */
+    public function grayscale(): void
+    {
+        $this->image->grayscale();
+    }
+
+    /**
+     * Alias of grayscale() for callers using British spelling.
+     *
+     * @return void
+     */
+    public function greyscale(): void
+    {
+        $this->grayscale();
+    }
+
+    /**
+     * Tints the image by shifting the red, green and blue channels. Each
+     * value ranges from -100 to 100.
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @return void
+     */
+    public function colorize(array $arguments): void
+    {
+        $red = (int)($arguments['red'] ?? 0);
+        $green = (int)($arguments['green'] ?? 0);
+        $blue = (int)($arguments['blue'] ?? 0);
+
+        $this->image->colorize($red, $green, $blue);
+    }
+
+    /**
+     * Blurs the image. Level ranges from 0 to 100; defaults to 5.
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @return void
+     */
+    public function blur(array $arguments): void
+    {
+        $level = (int)($arguments['level'] ?? 5);
+        $this->image->blur($level);
+    }
+
+    /**
+     * Pixelates the image with the given block size in pixels.
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function pixelate(array $arguments): void
+    {
+        if (!isset($arguments['size'])) {
+            throw new InvalidArgumentException('Missing size');
+        }
+
+        $this->image->pixelate((int)$arguments['size']);
+    }
+
+    /**
+     * Trims border areas of similar color around the image. Tolerance defaults
+     * to 0 (only exactly matching colors are trimmed).
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @return void
+     */
+    public function trim(array $arguments): void
+    {
+        $tolerance = (int)($arguments['tolerance'] ?? 0);
+        $this->image->trim($tolerance);
+    }
+
+    /**
+     * Resizes the canvas without resampling the original image. Use this to
+     * extend or shrink the working area; new areas are filled with the given
+     * background color.
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function resizeCanvas(array $arguments): void
+    {
+        if (!isset($arguments['width'], $arguments['height'])) {
+            throw new InvalidArgumentException('Missing width or height');
+        }
+
+        $arguments += [
+            'background' => null,
+            'position' => static::POSITION_CENTER,
+        ];
+
+        $this->image->resizeCanvas(
+            (int)$arguments['width'],
+            (int)$arguments['height'],
+            $arguments['background'],
+            $arguments['position'],
+        );
+    }
+
+    /**
+     * Adds padding around the image by extending the canvas relative to the
+     * current dimensions. `amount` adds N pixels on each side, or pass `width`
+     * and `height` for asymmetric padding.
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @return void
+     */
+    public function padding(array $arguments): void
+    {
+        $amount = isset($arguments['amount']) ? (int)$arguments['amount'] : null;
+        $width = isset($arguments['width']) ? (int)$arguments['width'] : ($amount !== null ? $amount * 2 : 0);
+        $height = isset($arguments['height']) ? (int)$arguments['height'] : ($amount !== null ? $amount * 2 : 0);
+
+        $this->image->resizeCanvasRelative(
+            $width,
+            $height,
+            $arguments['background'] ?? null,
+            $arguments['position'] ?? static::POSITION_CENTER,
+        );
+    }
+
+    /**
+     * Inserts another image (typically a watermark) on top of the current one.
+     * `image` accepts a file path, image data string, or any value
+     * intervention/image's insert() accepts.
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function place(array $arguments): void
+    {
+        if (!isset($arguments['image'])) {
+            throw new InvalidArgumentException('Missing image');
+        }
+
+        $position = $arguments['position'] ?? static::POSITION_BOTTOM_CENTER;
+        $x = (int)($arguments['x'] ?? 0);
+        $y = (int)($arguments['y'] ?? 0);
+        $opacity = (float)($arguments['opacity'] ?? 1);
+
+        $this->image->insert($arguments['image'], $x, $y, $position, $opacity);
+    }
+
+    /**
+     * Records a target output format for this variant. The processor will
+     * encode the variant using this extension instead of the source file's
+     * extension and adjust the variant path accordingly.
+     *
+     * Example: `'convert' => ['format' => 'webp']` stores a JPEG source as
+     * a WebP variant.
+     *
+     * @param array<string, mixed> $arguments Arguments
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function convert(array $arguments): void
+    {
+        if (!isset($arguments['format'])) {
+            throw new InvalidArgumentException('Missing format');
+        }
+
+        $this->outputFormat = strtolower((string)$arguments['format']);
     }
 
     /**

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -14,6 +14,7 @@
 
 namespace PhpCollective\Infrastructure\Storage\Processor\Image;
 
+use Intervention\Image\Direction;
 use Intervention\Image\Interfaces\ImageInterface;
 use InvalidArgumentException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOperationException;
@@ -21,7 +22,7 @@ use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOp
 /**
  * Operations
  *
- * @link https://image.intervention.io/v3
+ * @link https://image.intervention.io/v4
  */
 class Operations
 {
@@ -153,10 +154,10 @@ class Operations
         if ($arguments['x'] !== null && $arguments['y'] !== null) {
             $x = (int)$arguments['x'];
             $y = (int)$arguments['y'];
-            $this->image->crop($width, $height, $x, $y, position: $arguments['position']);
+            $this->image->crop($width, $height, $x, $y, alignment: $arguments['position']);
         } else {
             // Use position-based cropping only
-            $this->image->crop($width, $height, position: $arguments['position']);
+            $this->image->crop($width, $height, alignment: $arguments['position']);
         }
     }
 
@@ -202,12 +203,12 @@ class Operations
         }
 
         if ($arguments['direction'] === 'h') {
-            $this->image->flip();
+            $this->image->flip(Direction::HORIZONTAL);
 
             return;
         }
 
-        $this->image->flop();
+        $this->image->flip(Direction::VERTICAL);
     }
 
     /**

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -16,6 +16,7 @@ namespace PhpCollective\Test\TestCase\Processor\Image;
 
 use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
+use InvalidArgumentException;
 use PhpCollective\Infrastructure\Storage\File;
 use PhpCollective\Infrastructure\Storage\FileFactory;
 use PhpCollective\Infrastructure\Storage\FileStorageInterface;
@@ -67,5 +68,104 @@ class ImageProcessorTest extends TestCase
         $file = $processor->process($file);
 
         $this->assertInstanceOf(File::class, $file);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetQualityRejectsInvalidInteger(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->expectException(InvalidArgumentException::class);
+        $processor->setQuality(0);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetQualityRejectsTooHighInteger(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->expectException(InvalidArgumentException::class);
+        $processor->setQuality(101);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetQualityAcceptsArrayMap(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->assertSame($processor, $processor->setQuality([
+            'webp' => 80,
+            'JPG' => 90,
+        ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetQualityRejectsInvalidMapValue(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->expectException(InvalidArgumentException::class);
+        $processor->setQuality(['webp' => 0]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetStripExifIsFluent(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->assertSame($processor, $processor->setStripExif(false));
+    }
+
+    /**
+     * @return void
+     */
+    public function testConvertOperationSwapsVariantPathExtension(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $fileOnDisk = $this->getFixtureFile('titus.jpg');
+
+        $file = FileFactory::fromDisk($fileOnDisk, 'local')
+            ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973')
+            ->withFilename('foobar.jpg')
+            ->addToCollection('avatar')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $collection
+            ->addNew('asWebp')
+            ->resize(100, 100)
+            ->convert('webp');
+
+        $file = $file->withVariants($collection->toArray());
+        $file = $processor->process($file);
+
+        $variants = $file->variants();
+        $this->assertArrayHasKey('asWebp', $variants);
+        $this->assertStringEndsWith('.webp', $variants['asWebp']['path']);
+    }
+
+    /**
+     * @return \PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor
+     */
+    protected function buildProcessor(): ImageProcessor
+    {
+        $fileStorage = $this->createMock(FileStorageInterface::class);
+
+        return new ImageProcessor(
+            $fileStorage,
+            new PathBuilder(),
+            new ImageManager(new Driver()),
+        );
     }
 }

--- a/tests/TestCase/Processor/Image/OperationsTest.php
+++ b/tests/TestCase/Processor/Image/OperationsTest.php
@@ -132,4 +132,229 @@ class OperationsTest extends TestCase
         $this->expectExceptionMessage('Missing width or height');
         $operations->crop([]);
     }
+
+    /**
+     * @return void
+     */
+    public function testOrient(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('orient');
+
+        $operations = new Operations($imageMock);
+        $operations->orient();
+    }
+
+    /**
+     * @return void
+     */
+    public function testBrightness(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('brightness')->with(20);
+
+        $operations = new Operations($imageMock);
+        $operations->brightness(['level' => 20]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing level');
+        $operations->brightness([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testContrast(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('contrast')->with(-15);
+
+        $operations = new Operations($imageMock);
+        $operations->contrast(['level' => -15]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGrayscale(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->exactly(2))->method('grayscale');
+
+        $operations = new Operations($imageMock);
+        $operations->grayscale();
+        $operations->greyscale();
+    }
+
+    /**
+     * @return void
+     */
+    public function testColorize(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('colorize')->with(10, -5, 20);
+
+        $operations = new Operations($imageMock);
+        $operations->colorize(['red' => 10, 'green' => -5, 'blue' => 20]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testColorizeDefaultsToZero(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('colorize')->with(0, 0, 0);
+
+        $operations = new Operations($imageMock);
+        $operations->colorize([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBlur(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('blur')->with(7);
+
+        $operations = new Operations($imageMock);
+        $operations->blur(['level' => 7]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBlurDefaultLevel(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('blur')->with(5);
+
+        $operations = new Operations($imageMock);
+        $operations->blur([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPixelate(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('pixelate')->with(8);
+
+        $operations = new Operations($imageMock);
+        $operations->pixelate(['size' => 8]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing size');
+        $operations->pixelate([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testTrim(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())->method('trim')->with(15);
+
+        $operations = new Operations($imageMock);
+        $operations->trim(['tolerance' => 15]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testResizeCanvas(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())
+            ->method('resizeCanvas')
+            ->with(200, 200, '#ffffff', 'center');
+
+        $operations = new Operations($imageMock);
+        $operations->resizeCanvas([
+            'width' => 200,
+            'height' => 200,
+            'background' => '#ffffff',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing width or height');
+        $operations->resizeCanvas([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPadding(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())
+            ->method('resizeCanvasRelative')
+            ->with(20, 20, null, 'center');
+
+        $operations = new Operations($imageMock);
+        $operations->padding(['amount' => 10]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPaddingExplicitDimensions(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())
+            ->method('resizeCanvasRelative')
+            ->with(40, 10, '#000', 'center');
+
+        $operations = new Operations($imageMock);
+        $operations->padding([
+            'width' => 40,
+            'height' => 10,
+            'background' => '#000',
+        ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPlace(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $imageMock->expects($this->once())
+            ->method('insert')
+            ->with('/tmp/wm.png', 5, 10, 'bottom-right', 0.5);
+
+        $operations = new Operations($imageMock);
+        $operations->place([
+            'image' => '/tmp/wm.png',
+            'position' => 'bottom-right',
+            'x' => 5,
+            'y' => 10,
+            'opacity' => 0.5,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing image');
+        $operations->place([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testConvert(): void
+    {
+        $imageMock = $this->createMock(ImageInterface::class);
+        $operations = new Operations($imageMock);
+
+        $this->assertNull($operations->getOutputFormat());
+
+        $operations->convert(['format' => 'WEBP']);
+        $this->assertSame('webp', $operations->getOutputFormat());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing format');
+        $operations->convert([]);
+    }
 }


### PR DESCRIPTION
## Summary

Adapts the package to `intervention/image` v4 and uses the major bump to widen what the processor can do. v4 was released 2026-03 (latest 4.0.2) and introduced several breaking changes that touch every place this package interacts with the library.

This PR is intended to ship as `2.0.0`.

## v4 adaptation

- **`composer.json`**
  - `php`: `>=8.1` → `>=8.3` (v4 requires PHP 8.3+)
  - `intervention/image`: `^3.2.0` → `^4.0`

- **`src/ImageProcessor.php`**
  - `ImageManager::read()` → `decodePath()`. The auto-detecting `decode()` cascade tries the Base64 decoder first and misinterprets file paths, so the path-specific decoder is the right call here.
  - `encodeByExtension()` → `encodeUsingFileExtension()`. Wrapped in a small `encodeImage()` helper that only forwards `quality:` and `strip:` for encoders that accept them; v4 raises on unknown named arguments, so passing `quality` to `PngEncoder` or `GifEncoder` would throw.
  - `EncodedImage::toFilePointer()` is removed in v4. Replaced with a `php://temp` stream populated from `(string)$encoded`.

- **`src/Operations.php`**
  - `flop()` is removed; `flip()` now takes a `Direction` enum. `'h'` direction maps to `Direction::HORIZONTAL`, `'v'` to `Direction::VERTICAL`. Worth flagging: in v3 `flip()` (no arg) mirrored vertically, so `flipHorizontal()` was previously producing a vertical mirror — this PR makes the name match the behavior.
  - `crop(..., position:)` named argument → `alignment:` (parameter renamed in v4).
  - Updated `@link` reference to point at the v4 docs.

## New functionality

The 2.0 bump is also used to ship features the processor was missing. None of these add breaking surface — they're all additive.

### Wider format coverage

- The default MIME-type allowlist now includes `image/webp`, `image/avif`, `image/heic`, `image/heif`, `image/tiff` and `image/bmp` on top of `image/gif|jpg|jpeg|png`. These were already supported by intervention but were silently skipped by the processor.
- The encoder allowlist for `quality:`/`strip:` named args also covers `pjpg`/`pjpeg` (progressive JPEG, added in intervention 4.0.1), `heif`, `tif`, `jp2`, `j2k`.

### `setQuality(int|array)` — per-format quality

`setQuality(90)` keeps working. New: `setQuality(['webp' => 80, 'jpg' => 90, 'avif' => 70])` lets each format use its own quality, since WebP/AVIF look great well below typical JPEG settings.

### `setStripExif(bool)` — metadata stripping toggle

Defaults to `true` (strip metadata) — better for privacy and file size. Forwarded only to encoders that accept it (jpg/jpeg/pjpg/webp/avif/heic/heif/tiff/jp2/j2k). Call `setStripExif(false)` to preserve EXIF/ICC.

### New operations

First-class wrappers for intervention v4 operations the processor previously only exposed via `callback`:

| Operation | Notes |
|-----------|-------|
| `orient` | Auto-rotate based on EXIF — best as the first op on camera uploads |
| `brightness`, `contrast` | -100..100 |
| `grayscale` (alias `greyscale`) | British/American naming both work |
| `colorize` | Per-channel red/green/blue shifts |
| `blur`, `pixelate` | Stylistic / privacy redaction |
| `trim` | Strip uniform-color border areas |
| `resizeCanvas`, `padding` | Grow/shrink working area without resampling |
| `place` | Insert overlay (e.g. watermark) at position with offset and opacity |
| `convert` | Re-encode the variant in a different format than the source |

`convert` is worth a callout: a variant configured with `'convert' => ['format' => 'webp']` is encoded as WebP and stored under a `.webp` extension regardless of the source format. The processor reads the requested format back via `Operations::getOutputFormat()` and swaps both the encode extension and the variant path's extension.

`ImageVariant` gains matching fluent builder methods for each operation.

## Behavior notes

- The `Operations::POSITION_*` string constants (`'center'`, `'left-top'`, …) keep working because v4's `cover()` and `crop()` accept `string|Alignment` for the alignment parameter.
- Breaking change for downstream consumers: PHP 8.3 is now required, and any caller relying on the v3 `flipHorizontal()` quirk (vertical-flip behavior) will see a real horizontal flip after upgrade.
- EXIF stripping default flips from "intervention default" to `true`. Apps that need EXIF preserved must call `setStripExif(false)`.

## Verification

- `vendor/bin/phpunit` — 33 tests, 109 assertions, all passing
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs -s` — no errors