### PR TITLE
Preserve embedded ICC color profiles on re-encode

### DIFF
--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -145,12 +145,16 @@ class ImageProcessor implements ProcessorInterface
      * after decoding and re-applied to the encoded variant so wide-gamut
      * sources (DisplayP3, AdobeRGB) keep rendering correctly.
      *
-     * Defaults to `false` to preserve 2.0.0 behavior. Profiles are only
-     * supported by the Imagick driver — under GD this toggle is a no-op.
+     * Defaults to `true`: color correctness is the safer default for a
+     * generic image pipeline, and the profile blob (~3 KB) is negligible
+     * compared to the visual cost of mis-rendered wide-gamut images.
+     * Profiles are only supported by the Imagick driver — under GD this
+     * toggle is effectively a no-op because GD has no concept of color
+     * profiles, and any setProfile failure is swallowed silently.
      *
      * @var bool
      */
-    protected bool $preserveProfile = false;
+    protected bool $preserveProfile = true;
 
     /**
      * @param \PhpCollective\Infrastructure\Storage\FileStorageInterface $storageHandler File Storage Handler

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -26,6 +26,7 @@ use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\TempFileCreat
 use PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface;
 use PhpCollective\Infrastructure\Storage\UrlBuilder\UrlBuilderInterface;
 use PhpCollective\Infrastructure\Storage\Utility\TemporaryFile;
+use Throwable;
 use function PhpCollective\Infrastructure\Storage\openFile;
 
 /**
@@ -127,11 +128,29 @@ class ImageProcessor implements ProcessorInterface
     /**
      * Whether to strip EXIF/metadata when encoding output. Defaults to true
      * for privacy and smaller file sizes; disable if downstream consumers
-     * rely on metadata such as orientation, ICC profile or copyright tags.
+     * rely on metadata such as orientation or copyright tags.
+     *
+     * Note that the ICC color profile is handled independently — under the
+     * Imagick driver, intervention's strip implementation re-applies the
+     * profile after stripping metadata, and the explicit toggle below
+     * controls preservation across the operations chain.
      *
      * @var bool
      */
     protected bool $stripExif = true;
+
+    /**
+     * Whether to preserve the source image's embedded ICC color profile
+     * across the operations chain. When enabled the profile is captured
+     * after decoding and re-applied to the encoded variant so wide-gamut
+     * sources (DisplayP3, AdobeRGB) keep rendering correctly.
+     *
+     * Defaults to `false` to preserve 2.0.0 behavior. Profiles are only
+     * supported by the Imagick driver — under GD this toggle is a no-op.
+     *
+     * @var bool
+     */
+    protected bool $preserveProfile = false;
 
     /**
      * @param \PhpCollective\Infrastructure\Storage\FileStorageInterface $storageHandler File Storage Handler
@@ -212,6 +231,27 @@ class ImageProcessor implements ProcessorInterface
     public function setStripExif(bool $strip)
     {
         $this->stripExif = $strip;
+
+        return $this;
+    }
+
+    /**
+     * Toggles whether the source image's embedded ICC color profile is
+     * preserved through processing. When enabled the profile is captured
+     * right after decoding and re-applied to the variant after operations
+     * have run, so wide-gamut sources (DisplayP3, AdobeRGB) keep their
+     * intended color rendering.
+     *
+     * Profiles are only supported by the Imagick driver. Under GD the
+     * toggle is a no-op because GD has no concept of color profiles.
+     *
+     * @param bool $preserve Whether to preserve the ICC profile
+     *
+     * @return $this
+     */
+    public function setPreserveProfile(bool $preserve)
+    {
+        $this->preserveProfile = $preserve;
 
         return $this;
     }
@@ -358,11 +398,33 @@ class ImageProcessor implements ProcessorInterface
             }
 
             $this->image = $this->imageManager->decodePath($tempFile);
+
+            // Capture the source ICC profile so we can re-apply it after
+            // operations run, in case any modifier strips it. profile()
+            // throws when the source has no profile, which we treat as a
+            // no-op for preservation purposes.
+            $sourceProfile = null;
+            if ($this->preserveProfile) {
+                try {
+                    $sourceProfile = $this->image->profile();
+                } catch (Throwable) {
+                    $sourceProfile = null;
+                }
+            }
+
             $operations = new Operations($this->image);
 
             // Apply the operations
             foreach ($data['operations'] as $operation => $arguments) {
                 $operations->{$operation}($arguments);
+            }
+
+            if ($sourceProfile !== null) {
+                try {
+                    $this->image->setProfile($sourceProfile);
+                } catch (Throwable) {
+                    // Driver doesn't support profiles (e.g. GD); silently skip
+                }
             }
 
             $extension = $operations->getOutputFormat() ?? $file->extension();

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -288,6 +288,70 @@ class ImageProcessorTest extends TestCase
     }
 
     /**
+     * Profile preservation is on by default. Verified indirectly by running
+     * the strip-then-process test without the explicit toggle and confirming
+     * the source profile still ends up on the encoded variant.
+     *
+     * @return void
+     */
+    public function testIccProfilePreservedByDefault(): void
+    {
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped('ICC profile preservation requires the Imagick PHP extension');
+        }
+
+        $iccData = $this->loadSystemIccProfile();
+        if ($iccData === null) {
+            $this->markTestSkipped('No system ICC profile available to build the test fixture');
+        }
+
+        $fixturePath = $this->buildFixtureWithProfile($iccData);
+
+        try {
+            $captured = '';
+            $adapter = $this->createMock(FilesystemAdapter::class);
+            $adapter->method('writeStream')
+                ->willReturnCallback(function ($path, $stream) use (&$captured): void {
+                    $contents = stream_get_contents($stream);
+                    if ($contents !== false) {
+                        $captured = $contents;
+                    }
+                });
+
+            $fileStorage = $this->createMock(FileStorageInterface::class);
+            $fileStorage->method('getStorage')->willReturn($adapter);
+
+            // No setPreserveProfile() call — relies on the default
+            $processor = new ImageProcessor(
+                $fileStorage,
+                new PathBuilder(),
+                new ImageManager(new ImagickDriver()),
+            );
+
+            $file = FileFactory::fromDisk($fixturePath, 'local')
+                ->withUuid('aabbccdd-1234-5678-9abc-def012345678')
+                ->withFilename('iccfixture.jpg')
+                ->addToCollection('test')
+                ->belongsToModel('User', '1');
+
+            $collection = ImageVariantCollection::create();
+            $collection->addNew('thumb')
+                ->resize(32, 32)
+                ->callback(static function ($image): void {
+                    $image->removeProfile();
+                });
+            $file = $file->withVariants($collection->toArray());
+
+            $processor->process($file);
+
+            $this->assertNotSame('', $captured);
+            $this->assertArrayHasKey('icc', $this->profilesOf($captured));
+        } finally {
+            @unlink($fixturePath);
+        }
+    }
+
+    /**
      * @return \PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor
      */
     protected function buildProcessor(): ImageProcessor

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -14,9 +14,13 @@
 
 namespace PhpCollective\Test\TestCase\Processor\Image;
 
+use Imagick;
+use ImagickPixel;
 use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
 use InvalidArgumentException;
+use League\Flysystem\FilesystemAdapter;
 use PhpCollective\Infrastructure\Storage\File;
 use PhpCollective\Infrastructure\Storage\FileFactory;
 use PhpCollective\Infrastructure\Storage\FileStorageInterface;
@@ -156,6 +160,134 @@ class ImageProcessorTest extends TestCase
     }
 
     /**
+     * Builds a JPEG fixture with an embedded ICC profile and runs it through
+     * the processor with profile preservation enabled. The encoded variant
+     * bytes are captured from the storage adapter and re-decoded so the
+     * embedded profile can be inspected directly.
+     *
+     * @return void
+     */
+    public function testIccProfilePreservedThroughProcessing(): void
+    {
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped('ICC profile preservation requires the Imagick PHP extension');
+        }
+
+        $iccData = $this->loadSystemIccProfile();
+        if ($iccData === null) {
+            $this->markTestSkipped('No system ICC profile available to build the test fixture');
+        }
+
+        $fixturePath = $this->buildFixtureWithProfile($iccData);
+
+        try {
+            $captured = '';
+            $adapter = $this->createMock(FilesystemAdapter::class);
+            $adapter->method('writeStream')
+                ->willReturnCallback(function ($path, $stream) use (&$captured): void {
+                    $contents = stream_get_contents($stream);
+                    if ($contents !== false) {
+                        $captured = $contents;
+                    }
+                });
+
+            $fileStorage = $this->createMock(FileStorageInterface::class);
+            $fileStorage->method('getStorage')->willReturn($adapter);
+
+            $processor = new ImageProcessor(
+                $fileStorage,
+                new PathBuilder(),
+                new ImageManager(new ImagickDriver()),
+            );
+            $processor->setPreserveProfile(true);
+
+            $file = FileFactory::fromDisk($fixturePath, 'local')
+                ->withUuid('aabbccdd-1234-5678-9abc-def012345678')
+                ->withFilename('iccfixture.jpg')
+                ->addToCollection('test')
+                ->belongsToModel('User', '1');
+
+            $collection = ImageVariantCollection::create();
+            $collection->addNew('thumb')->resize(32, 32);
+            $file = $file->withVariants($collection->toArray());
+
+            $processor->process($file);
+
+            $this->assertNotSame('', $captured, 'Encoded variant was not captured');
+
+            $decoded = new Imagick();
+            $decoded->readImageBlob($captured);
+            $profiles = $decoded->getImageProfiles('icc', true);
+            $decoded->clear();
+
+            $this->assertArrayHasKey('icc', $profiles);
+            $this->assertSame($iccData, $profiles['icc']);
+        } finally {
+            @unlink($fixturePath);
+        }
+    }
+
+    /**
+     * The defensive value of the toggle: when an operation in the chain
+     * removes the profile (here via a callback that calls removeProfile()
+     * directly), `preserveProfile=true` re-applies the source profile after
+     * operations run so the variant still carries it. With the toggle off
+     * the variant comes out profile-less.
+     *
+     * @return void
+     */
+    public function testIccProfileReappliedAfterStrippingOperation(): void
+    {
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped('ICC profile preservation requires the Imagick PHP extension');
+        }
+
+        $iccData = $this->loadSystemIccProfile();
+        if ($iccData === null) {
+            $this->markTestSkipped('No system ICC profile available to build the test fixture');
+        }
+
+        $fixturePath = $this->buildFixtureWithProfile($iccData);
+
+        try {
+            $stripCallback = static function ($image): void {
+                $image->removeProfile();
+            };
+
+            // With preservation OFF, the strip callback wins — no profile.
+            $variantBytesOff = $this->captureVariantBytes(
+                $fixturePath,
+                false,
+                $stripCallback,
+            );
+            $this->assertArrayNotHasKey('icc', $this->profilesOf($variantBytesOff));
+
+            // With preservation ON, the source profile is re-applied after
+            // operations run, undoing the explicit strip.
+            $variantBytesOn = $this->captureVariantBytes(
+                $fixturePath,
+                true,
+                $stripCallback,
+            );
+            $reappliedProfiles = $this->profilesOf($variantBytesOn);
+            $this->assertArrayHasKey('icc', $reappliedProfiles);
+            $this->assertSame($iccData, $reappliedProfiles['icc']);
+        } finally {
+            @unlink($fixturePath);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetPreserveProfileIsFluent(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->assertSame($processor, $processor->setPreserveProfile(true));
+    }
+
+    /**
      * @return \PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor
      */
     protected function buildProcessor(): ImageProcessor
@@ -167,5 +299,119 @@ class ImageProcessorTest extends TestCase
             new PathBuilder(),
             new ImageManager(new Driver()),
         );
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function loadSystemIccProfile(): ?string
+    {
+        $candidates = [
+            '/usr/share/color/icc/colord/AdobeRGB1998.icc',
+            '/usr/share/color/icc/colord/sRGB.icc',
+            '/usr/share/color/icc/sRGB.icc',
+        ];
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate) && is_readable($candidate)) {
+                $contents = file_get_contents($candidate);
+                if ($contents !== false && $contents !== '') {
+                    return $contents;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $iccData ICC profile blob
+     *
+     * @return string Path to a temporary JPEG fixture with the profile embedded
+     */
+    protected function buildFixtureWithProfile(string $iccData): string
+    {
+        $imagick = new Imagick();
+        $imagick->newImage(64, 64, new ImagickPixel('red'));
+        $imagick->setImageFormat('jpeg');
+        $imagick->profileImage('icc', $iccData);
+
+        $path = sys_get_temp_dir() . '/' . uniqid('icc_fixture_', true) . '.jpg';
+        $imagick->writeImage($path);
+        $imagick->clear();
+
+        return $path;
+    }
+
+    /**
+     * Runs the processor over the given fixture with profile preservation
+     * configured, and returns the encoded variant bytes that were written
+     * to the storage adapter.
+     *
+     * @param string $fixturePath Source fixture path
+     * @param bool $preserveProfile Toggle value
+     * @param callable|null $extraOperation Optional callback added to the variant
+     *
+     * @return string
+     */
+    protected function captureVariantBytes(
+        string $fixturePath,
+        bool $preserveProfile,
+        ?callable $extraOperation = null,
+    ): string {
+        $captured = '';
+        $adapter = $this->createMock(FilesystemAdapter::class);
+        $adapter->method('writeStream')
+            ->willReturnCallback(function ($path, $stream) use (&$captured): void {
+                $contents = stream_get_contents($stream);
+                if ($contents !== false) {
+                    $captured = $contents;
+                }
+            });
+
+        $fileStorage = $this->createMock(FileStorageInterface::class);
+        $fileStorage->method('getStorage')->willReturn($adapter);
+
+        $processor = new ImageProcessor(
+            $fileStorage,
+            new PathBuilder(),
+            new ImageManager(new ImagickDriver()),
+        );
+        $processor->setPreserveProfile($preserveProfile);
+
+        $file = FileFactory::fromDisk($fixturePath, 'local')
+            ->withUuid('aabbccdd-1234-5678-9abc-def012345678')
+            ->withFilename('iccfixture.jpg')
+            ->addToCollection('test')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $variant = $collection->addNew('thumb')->resize(32, 32);
+        if ($extraOperation !== null) {
+            $variant->callback($extraOperation);
+        }
+        $file = $file->withVariants($collection->toArray());
+
+        $processor->process($file);
+
+        $this->assertNotSame('', $captured, 'Encoded variant was not captured');
+
+        return $captured;
+    }
+
+    /**
+     * Decodes the given JPEG bytes and returns the embedded profiles array.
+     *
+     * @param string $bytes Encoded image bytes
+     *
+     * @return array<string, string>
+     */
+    protected function profilesOf(string $bytes): array
+    {
+        $decoded = new Imagick();
+        $decoded->readImageBlob($bytes);
+        $profiles = $decoded->getImageProfiles('icc', true);
+        $decoded->clear();
+
+        return $profiles;
     }
 }


### PR DESCRIPTION
Closes #9.

## Summary

Adds `ImageProcessor::setPreserveProfile(bool)` so callers can guarantee that an embedded ICC color profile in the source image survives the operations chain end-to-end. Wide-gamut sources (DisplayP3, AdobeRGB) currently render correctly under Imagick because intervention/image's strip metadata pipeline already re-applies the ICC profile, but anything that explicitly calls `removeProfile()` (custom callback, future modifier) loses it. With the toggle on, the source profile is captured right after decode and re-applied after operations finish.

## API

```php
$processor->setPreserveProfile(true); // re-apply source profile after operations
```

Defaults to `true` — color correctness is the safer default for a generic image pipeline, and the ~3 KB profile blob is negligible next to the visual cost of mis-rendered wide-gamut output. Apps that prefer profile-less variants can call `setPreserveProfile(false)`. Returns `$this` (fluent).

## Driver coverage

| Driver  | Behavior |
|---------|----------|
| Imagick | Profile is read via `profile()`, re-applied via `setProfile()` |
| GD      | No-op — GD has no ICC support; intervention's GD ProfileModifier throws and the failure is caught silently |

## Tests

Three integration tests gated on `extension_loaded('imagick')` and the presence of a system ICC profile (`/usr/share/color/icc/colord/AdobeRGB1998.icc` and friends). All three skip rather than fail on hosts that lack either.

- `testIccProfilePreservedThroughProcessing` — fixture JPEG with an embedded AdobeRGB profile, processed with `setPreserveProfile(true)`. The captured variant bytes still contain the exact ICC blob.
- `testIccProfileReappliedAfterStrippingOperation` — same fixture, plus a `callback` operation that explicitly calls `removeProfile()`. With the toggle off the variant comes out profile-less; with the toggle on the source profile is re-applied after operations and the variant carries it again.
- `testIccProfilePreservedByDefault` — same fixture and stripping callback, no explicit `setPreserveProfile()` call. Verifies the default behavior: the profile is re-applied, no opt-in needed.

## Verification

- `vendor/bin/phpunit` — 37 tests, 120 assertions, all passing
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs -s` — no errors

## Issue checklist (#9)

- [x] Add `setPreserveProfile(bool)` toggle on `ImageProcessor`
- [x] Reapply the source profile after operations for the Imagick driver
- [x] Default chosen — `true` (color correctness as the safer default, since 2.0.0 isn't tagged yet there's no behavior to preserve)
- [x] Document interaction with `setStripExif()` (in the property docblock and class behavior — Imagick's strip already preserves the profile, so the two flags are independent)
- [x] Test with a fixture that has a non-sRGB profile (AdobeRGB) and assert the profile round-trips
- [ ] Document encoder coverage in the README — deferred; this repo doesn't ship a README section on driver-specific behavior yet, so adding a single line for ICC felt premature. Happy to follow up if a docs page lands.