### PR TITLE
Add ImageProcessor::create driver factory helper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,13 @@ composer require php-collective/file-storage-image-processor
 ## Quick Example
 
 ```php
+use PhpCollective\Infrastructure\Storage\Processor\Image\Driver;
+use PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariantCollection;
+
+// Driver::Auto picks Imagick when the extension is loaded and falls
+// back to GD; use Driver::Gd or Driver::Imagick to choose explicitly.
+$imageProcessor = ImageProcessor::create(Driver::Auto, $fileStorage, $pathBuilder);
 
 $collection = ImageVariantCollection::create();
 

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -1,14 +1,10 @@
 <?php declare(strict_types = 1);
 
 /**
- * Copyright (c) Florian Krämer (https://florian-kraemer.net)
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Florian Krämer (https://florian-kraemer.net)
- * @author Florian Krämer
- * @link https://github.com/Phauthentic
+ * @author Mark Scherer
  * @license https://opensource.org/licenses/MIT MIT License
  */
 

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * @author Florian Krämer
+ * @link https://github.com/Phauthentic
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Processor\Image;
+
+use Intervention\Image\Drivers\Gd\Driver as InterventionGdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as InterventionImagickDriver;
+use Intervention\Image\Interfaces\DriverInterface;
+use RuntimeException;
+
+/**
+ * Identifies which intervention/image driver `ImageProcessor::create()`
+ * should resolve. Use this enum instead of magic strings:
+ *
+ *     ImageProcessor::create(Driver::Imagick, $storage, $pathBuilder);
+ *     ImageProcessor::create(Driver::Auto, $storage, $pathBuilder);
+ */
+enum Driver: string
+{
+    /**
+     * Imagick when `ext-imagick` is loaded, otherwise GD. Raises a
+     * `RuntimeException` when neither extension is available.
+     */
+    case Auto = 'auto';
+
+    /**
+     * The PHP-built-in GD extension. Smaller install footprint, no ICC
+     * profile or color-space support.
+     */
+    case Gd = 'gd';
+
+    /**
+     * The Imagick extension. Wider format support, ICC color profiles,
+     * higher quality output.
+     */
+    case Imagick = 'imagick';
+
+    /**
+     * Resolves this enum case to a concrete intervention/image driver
+     * instance. Hidden behind the enum so callers never need to import
+     * intervention's driver classes directly.
+     *
+     * @return \Intervention\Image\Interfaces\DriverInterface
+     */
+    public function build(): DriverInterface
+    {
+        return match ($this) {
+            self::Gd => new InterventionGdDriver(),
+            self::Imagick => new InterventionImagickDriver(),
+            self::Auto => self::autoDetect(),
+        };
+    }
+
+    /**
+     * @throws \RuntimeException
+     *
+     * @return \Intervention\Image\Interfaces\DriverInterface
+     */
+    private static function autoDetect(): DriverInterface
+    {
+        if (extension_loaded('imagick')) {
+            return new InterventionImagickDriver();
+        }
+        if (extension_loaded('gd')) {
+            return new InterventionGdDriver();
+        }
+
+        throw new RuntimeException(
+            'Neither the Imagick nor the GD PHP extension is available; '
+            . 'install one or pass a configured ImageManager to the constructor instead.',
+        );
+    }
+}

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -13,6 +13,7 @@ namespace PhpCollective\Infrastructure\Storage\Processor\Image;
 use Intervention\Image\Drivers\Gd\Driver as InterventionGdDriver;
 use Intervention\Image\Drivers\Imagick\Driver as InterventionImagickDriver;
 use Intervention\Image\Interfaces\DriverInterface;
+use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -41,6 +42,34 @@ enum Driver: string
      * higher quality output.
      */
     case Imagick = 'imagick';
+
+    /**
+     * Resolves a driver name (e.g. from a config array) to the matching
+     * enum case. Lower-cases and trims the input so values like `'GD'`
+     * or `' imagick '` resolve correctly. Throws when the input does
+     * not match any known case.
+     *
+     * @param string $name Driver name (`'gd'`, `'imagick'`, `'auto'`)
+     *
+     * @throws \InvalidArgumentException When the name does not match any case
+     *
+     * @return self
+     */
+    public static function fromName(string $name): self
+    {
+        $case = self::tryFrom(strtolower(trim($name)));
+        if ($case !== null) {
+            return $case;
+        }
+
+        $valid = implode(', ', array_map(static fn (self $c): string => $c->value, self::cases()));
+
+        throw new InvalidArgumentException(sprintf(
+            'Unknown image driver "%s". Expected one of: %s.',
+            $name,
+            $valid,
+        ));
+    }
 
     /**
      * Resolves this enum case to a concrete intervention/image driver

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -175,6 +175,39 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
+     * Builds an ImageProcessor with the intervention/image manager wired
+     * up for you. Pass a `Driver` enum case to pick the driver:
+     *
+     *     ImageProcessor::create(Driver::Imagick, $storage, $pathBuilder);
+     *     ImageProcessor::create(Driver::Auto, $storage, $pathBuilder);
+     *
+     * Useful when the calling app does not need direct access to the
+     * `ImageManager` instance — most applications fit this case. Use the
+     * regular constructor when a custom-configured `ImageManager` is
+     * needed (e.g. with a non-default background color or font config).
+     *
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Driver $driver Driver enum case
+     * @param \PhpCollective\Infrastructure\Storage\FileStorageInterface $storageHandler File Storage Handler
+     * @param \PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilderInterface $pathBuilder Path Builder
+     * @param \PhpCollective\Infrastructure\Storage\UrlBuilder\UrlBuilderInterface|null $urlBuilder Url Builder
+     *
+     * @return self
+     */
+    public static function create(
+        Driver $driver,
+        FileStorageInterface $storageHandler,
+        PathBuilderInterface $pathBuilder,
+        ?UrlBuilderInterface $urlBuilder = null,
+    ): self {
+        return new self(
+            $storageHandler,
+            $pathBuilder,
+            new ImageManager($driver->build()),
+            $urlBuilder,
+        );
+    }
+
+    /**
      * @param array<int, string> $mimeTypes Mime Type List
      *
      * @return $this

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -176,17 +176,23 @@ class ImageProcessor implements ProcessorInterface
 
     /**
      * Builds an ImageProcessor with the intervention/image manager wired
-     * up for you. Pass a `Driver` enum case to pick the driver:
+     * up for you. Pass a `Driver` enum case (preferred — type-safe) or
+     * an equivalent string (`'gd'`, `'imagick'`, `'auto'`) for setups
+     * that read the driver name from config or env vars:
      *
      *     ImageProcessor::create(Driver::Imagick, $storage, $pathBuilder);
      *     ImageProcessor::create(Driver::Auto, $storage, $pathBuilder);
+     *     ImageProcessor::create($config['driver'] ?? 'auto', $storage, $pathBuilder);
      *
-     * Useful when the calling app does not need direct access to the
-     * `ImageManager` instance — most applications fit this case. Use the
-     * regular constructor when a custom-configured `ImageManager` is
-     * needed (e.g. with a non-default background color or font config).
+     * String input is lower-cased and trimmed before resolution, and an
+     * unknown name throws `InvalidArgumentException` with the list of
+     * accepted values.
      *
-     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Driver $driver Driver enum case
+     * Use the regular constructor when a custom-configured
+     * `ImageManager` is needed (e.g. with a non-default background
+     * color or font config).
+     *
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Driver|string $driver Driver enum case or equivalent string
      * @param \PhpCollective\Infrastructure\Storage\FileStorageInterface $storageHandler File Storage Handler
      * @param \PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilderInterface $pathBuilder Path Builder
      * @param \PhpCollective\Infrastructure\Storage\UrlBuilder\UrlBuilderInterface|null $urlBuilder Url Builder
@@ -194,11 +200,15 @@ class ImageProcessor implements ProcessorInterface
      * @return self
      */
     public static function create(
-        Driver $driver,
+        Driver|string $driver,
         FileStorageInterface $storageHandler,
         PathBuilderInterface $pathBuilder,
         ?UrlBuilderInterface $urlBuilder = null,
     ): self {
+        if (is_string($driver)) {
+            $driver = Driver::fromName($driver);
+        }
+
         return new self(
             $storageHandler,
             $pathBuilder,

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -17,17 +17,21 @@ namespace PhpCollective\Test\TestCase\Processor\Image;
 use Imagick;
 use ImagickPixel;
 use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\DriverInterface;
 use InvalidArgumentException;
 use League\Flysystem\FilesystemAdapter;
 use PhpCollective\Infrastructure\Storage\File;
 use PhpCollective\Infrastructure\Storage\FileFactory;
 use PhpCollective\Infrastructure\Storage\FileStorageInterface;
 use PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilder;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Driver as ImageDriver;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariantCollection;
 use PhpCollective\Test\TestCase\TestCase;
+use ReflectionClass;
 
 /**
  * ImageProcessorTest
@@ -352,6 +356,66 @@ class ImageProcessorTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testCreateWithExplicitGdDriver(): void
+    {
+        $processor = ImageProcessor::create(
+            ImageDriver::Gd,
+            $this->createMock(FileStorageInterface::class),
+            new PathBuilder(),
+        );
+
+        $this->assertInstanceOf(GdDriver::class, $this->driverOf($processor));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateWithExplicitImagickDriver(): void
+    {
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped('Imagick driver requires the Imagick PHP extension');
+        }
+
+        $processor = ImageProcessor::create(
+            ImageDriver::Imagick,
+            $this->createMock(FileStorageInterface::class),
+            new PathBuilder(),
+        );
+
+        $this->assertInstanceOf(ImagickDriver::class, $this->driverOf($processor));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateAutoPrefersImagickWhenAvailable(): void
+    {
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped('Auto-detect prefers Imagick; requires the extension');
+        }
+
+        $processor = ImageProcessor::create(
+            ImageDriver::Auto,
+            $this->createMock(FileStorageInterface::class),
+            new PathBuilder(),
+        );
+
+        $this->assertInstanceOf(ImagickDriver::class, $this->driverOf($processor));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDriverEnumStringValuesAreStable(): void
+    {
+        $this->assertSame('gd', ImageDriver::Gd->value);
+        $this->assertSame('imagick', ImageDriver::Imagick->value);
+        $this->assertSame('auto', ImageDriver::Auto->value);
+    }
+
+    /**
      * @return \PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor
      */
     protected function buildProcessor(): ImageProcessor
@@ -363,6 +427,24 @@ class ImageProcessorTest extends TestCase
             new PathBuilder(),
             new ImageManager(new Driver()),
         );
+    }
+
+    /**
+     * Reads the protected `imageManager` property and returns its driver,
+     * so tests can assert which driver the factory selected without having
+     * to expose it via a public getter.
+     *
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor $processor Processor
+     *
+     * @return \Intervention\Image\Interfaces\DriverInterface
+     */
+    protected function driverOf(ImageProcessor $processor): DriverInterface
+    {
+        $reflection = new ReflectionClass($processor);
+        $property = $reflection->getProperty('imageManager');
+        $manager = $property->getValue($processor);
+
+        return $manager->driver;
     }
 
     /**

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -416,6 +416,70 @@ class ImageProcessorTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testCreateAcceptsDriverNameString(): void
+    {
+        $processor = ImageProcessor::create(
+            'gd',
+            $this->createMock(FileStorageInterface::class),
+            new PathBuilder(),
+        );
+
+        $this->assertInstanceOf(GdDriver::class, $this->driverOf($processor));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateNormalisesDriverNameString(): void
+    {
+        $processor = ImageProcessor::create(
+            '  GD  ',
+            $this->createMock(FileStorageInterface::class),
+            new PathBuilder(),
+        );
+
+        $this->assertInstanceOf(GdDriver::class, $this->driverOf($processor));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateThrowsOnUnknownDriverName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown image driver "vips"');
+
+        ImageProcessor::create(
+            'vips',
+            $this->createMock(FileStorageInterface::class),
+            new PathBuilder(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testDriverFromNameRoundTrip(): void
+    {
+        $this->assertSame(ImageDriver::Auto, ImageDriver::fromName('auto'));
+        $this->assertSame(ImageDriver::Gd, ImageDriver::fromName('GD'));
+        $this->assertSame(ImageDriver::Imagick, ImageDriver::fromName('  imagick  '));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDriverFromNameThrowsOnUnknown(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown image driver "vips". Expected one of: auto, gd, imagick.');
+
+        ImageDriver::fromName('vips');
+    }
+
+    /**
      * @return \PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor
      */
     protected function buildProcessor(): ImageProcessor


### PR DESCRIPTION
Closes #8.

## Summary

Adds a static factory so callers don't have to construct `ImageManager` themselves. The driver is selected via a typed `Driver` enum (preferred) — and runtime strings are accepted too for config-driven setups:

```php
use PhpCollective\Infrastructure\Storage\Processor\Image\Driver;
use PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor;

// Typed call sites use the enum
$processor = ImageProcessor::create(Driver::Imagick, $storage, $pathBuilder);
$processor = ImageProcessor::create(Driver::Auto, $storage, $pathBuilder);

// Config / env-var sources can pass the raw string
$processor = ImageProcessor::create($config['driver'] ?? 'auto', $storage, $pathBuilder);
$processor = ImageProcessor::create('IMAGICK', $storage, $pathBuilder); // case + whitespace normalised
```

String input is lower-cased and trimmed; unknown values throw `InvalidArgumentException` with the list of accepted names.

## The `Driver` enum

| Case | Behavior |
|------|----------|
| `Driver::Gd` | New `Intervention\Image\Drivers\Gd\Driver` |
| `Driver::Imagick` | New `Intervention\Image\Drivers\Imagick\Driver` |
| `Driver::Auto` | Imagick when `ext-imagick` is loaded, else GD. `RuntimeException` if neither is installed |

The enum exposes a `build(): DriverInterface` method that resolves the case to a concrete intervention driver, so callers never need to import intervention's driver classes directly. For runtime strings, `Driver::fromName(string)` does the case/whitespace normalisation and throws a clear `InvalidArgumentException` for unknown values.

## Why an enum

You asked specifically for less magic strings. PHP 8.1+ enums give us:

- IDE autocomplete on the call site
- A compile-time guarantee that `Driver::Imagick` is spelled correctly
- An exhaustive `match` over driver cases
- A natural place (`Driver::build()`) to hide the intervention-specific class wiring

## Backward compatibility

Fully back-compat — the existing constructor (`new ImageProcessor($storage, $pathBuilder, $manager, $urlBuilder)`) is unchanged and remains the path for advanced setups (custom background color, font configuration, etc.). The factory is purely additive.

## Tests

- `testCreateWithExplicitGdDriver` — `Driver::Gd` resolves to intervention's GD driver
- `testCreateWithExplicitImagickDriver` — `Driver::Imagick` resolves to Imagick (skipped when ext-imagick is absent)
- `testCreateAutoPrefersImagickWhenAvailable` — `Driver::Auto` picks Imagick when the extension is loaded
- `testDriverEnumStringValuesAreStable` — backing values stay `gd` / `imagick` / `auto`
- `testCreateAcceptsDriverNameString` — passing `'gd'` works the same as `Driver::Gd`
- `testCreateNormalisesDriverNameString` — `'  GD  '` resolves correctly
- `testCreateThrowsOnUnknownDriverName` — unknown string raises `InvalidArgumentException`
- `testDriverFromNameRoundTrip` — direct `Driver::fromName()` round-trips for all cases
- `testDriverFromNameThrowsOnUnknown` — error message lists the accepted names

The selected driver is read out of the protected `imageManager` property via reflection, so tests can assert the resolution path without exposing the manager publicly.

## Docs

`readme.md` Quick Example refreshed to use the new factory.

## Verification

- `vendor/bin/phpunit` — 46 tests, 135 assertions, all passing
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs -s` — no errors
- Branch is rebased onto latest `master` (post-#10) — no merge conflicts

## Issue checklist (#8)

- [x] Static factory `ImageProcessor::create(Driver, FileStorageInterface, PathBuilderInterface, ?UrlBuilderInterface)` resolving GD / Imagick — uses a typed enum instead of strings
- [x] `Driver::Auto` for auto-detect (Imagick preferred, GD fallback)
- [x] Existing constructor untouched — fully backwards-compatible
- [x] One test per resolution path
- [x] README snippet showing the short form