### PR TITLE
Cleanup: bug fixes, Position + FlipDirection enums, API hygiene

### DIFF
--- a/src/FlipDirection.php
+++ b/src/FlipDirection.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Processor\Image;
+
+use Intervention\Image\Direction;
+use InvalidArgumentException;
+
+/**
+ * Direction for the `flip` operation. Use this enum instead of magic
+ * `'h'` / `'v'` strings:
+ *
+ *     $variant->flip(FlipDirection::Horizontal);
+ *
+ * Backed by the same single-character codes the package has used since
+ * v1 so existing variant configs (`['direction' => 'h']`) continue to
+ * resolve correctly.
+ */
+enum FlipDirection: string
+{
+    case Horizontal = 'h';
+    case Vertical = 'v';
+
+    /**
+     * Resolves a direction code (e.g. from a config array) to the matching
+     * enum case. Lower-cases and trims the input, and accepts both the
+     * single-character codes (`h`, `v`) and the long forms
+     * (`horizontal`, `vertical`).
+     *
+     * @param string $name Direction code or name
+     *
+     * @throws \InvalidArgumentException When the input does not match any case
+     *
+     * @return self
+     */
+    public static function fromName(string $name): self
+    {
+        $normalized = strtolower(trim($name));
+
+        return match ($normalized) {
+            'h', 'horizontal' => self::Horizontal,
+            'v', 'vertical' => self::Vertical,
+            default => throw new InvalidArgumentException(sprintf(
+                'Unknown flip direction "%s". Expected one of: h, v, horizontal, vertical.',
+                $name,
+            )),
+        };
+    }
+
+    /**
+     * Returns the matching intervention/image `Direction` enum case so
+     * callers don't have to import intervention's enum directly.
+     *
+     * @return \Intervention\Image\Direction
+     */
+    public function intervention(): Direction
+    {
+        return match ($this) {
+            self::Horizontal => Direction::HORIZONTAL,
+            self::Vertical => Direction::VERTICAL,
+        };
+    }
+}

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -214,13 +214,31 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
-     * @param array<int, string> $mimeTypes Mime Type List
+     * Replaces the list of MIME types the processor will operate on.
+     * Files with any other MIME type are returned untouched by `process()`.
+     * Useful when the application wants to widen support to types the
+     * underlying intervention/image driver accepts but that aren't in
+     * the default allowlist, or to narrow it for security reasons.
+     *
+     * @param array<int, string> $mimeTypes MIME Type List, e.g. `['image/jpeg', 'image/png']`
+     *
+     * @throws \InvalidArgumentException When the list is empty or any entry is not a non-empty string
      *
      * @return $this
      */
-    protected function setMimeTypes(array $mimeTypes)
+    public function setMimeTypes(array $mimeTypes)
     {
-        $this->mimeTypes = $mimeTypes;
+        if ($mimeTypes === []) {
+            throw new InvalidArgumentException('MIME type list must not be empty');
+        }
+
+        foreach ($mimeTypes as $type) {
+            if ($type === '') {
+                throw new InvalidArgumentException('MIME type list must not contain empty strings');
+            }
+        }
+
+        $this->mimeTypes = array_values($mimeTypes);
 
         return $this;
     }
@@ -360,32 +378,41 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
-     * Read the data from the files resource if (still) present,
-     * if not fetch it from the storage backend and write the data
-     * to the stream of the temp file
+     * Copies the source file's bytes into the given temp-file stream,
+     * preferring the in-memory resource on the file object when present
+     * and falling back to a fresh read from storage. Closes the temp
+     * stream regardless of outcome and throws when the copy fails so
+     * callers don't have to remember to inspect the return value.
      *
      * @param \PhpCollective\Infrastructure\Storage\FileInterface $file File
      * @param resource $tempFileStream Temp File Stream Resource
+     * @param string $tempFile Path to the destination temp file (used in the error message)
      *
-     * @return int|bool False on error
+     * @throws \PhpCollective\Infrastructure\Storage\Processor\Image\Exception\TempFileCreationFailedException
+     *
+     * @return void
      */
-    protected function copyOriginalFileData(FileInterface $file, $tempFileStream)
+    protected function copyOriginalFileData(FileInterface $file, $tempFileStream, string $tempFile): void
     {
         $stream = $file->resource();
-        $storage = $this->storageHandler->getStorage($file->storage());
-
         if ($stream === null) {
+            $storage = $this->storageHandler->getStorage($file->storage());
             $stream = $storage->readStream($file->path());
         } else {
             rewind($stream);
         }
-        $result = stream_copy_to_stream(
-            $stream,
-            $tempFileStream,
-        );
-        fclose($tempFileStream);
 
-        return $result;
+        try {
+            $result = stream_copy_to_stream($stream, $tempFileStream);
+        } finally {
+            fclose($tempFileStream);
+        }
+
+        if ($result === false) {
+            $this->safeUnlink($tempFile);
+
+            throw TempFileCreationFailedException::withFilename($tempFile);
+        }
     }
 
     /**
@@ -409,8 +436,6 @@ class ImageProcessor implements ProcessorInterface
 
     /**
      * @inheritDoc
-     *
-     * @throws \PhpCollective\Infrastructure\Storage\Processor\Image\Exception\TempFileCreationFailedException
      */
     public function process(FileInterface $file): FileInterface
     {
@@ -423,12 +448,7 @@ class ImageProcessor implements ProcessorInterface
         $tempFile = TemporaryFile::create();
         $tempFileStream = openFile($tempFile, 'wb+');
 
-        $result = $this->copyOriginalFileData($file, $tempFileStream);
-        if ($result === false) {
-            $this->safeUnlink($tempFile);
-
-            throw TempFileCreationFailedException::withFilename($tempFile);
-        }
+        $this->copyOriginalFileData($file, $tempFileStream, $tempFile);
 
         try {
             foreach ($file->variants() as $variant => $data) {

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -19,6 +19,7 @@ use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use InvalidArgumentException;
 use League\Flysystem\Config;
+use League\Flysystem\FilesystemAdapter;
 use PhpCollective\Infrastructure\Storage\FileInterface;
 use PhpCollective\Infrastructure\Storage\FileStorageInterface;
 use PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilderInterface;
@@ -105,11 +106,6 @@ class ImageProcessor implements ProcessorInterface
      * @var \Intervention\Image\ImageManager
      */
     protected ImageManager $imageManager;
-
-    /**
-     * @var \Intervention\Image\Interfaces\ImageInterface
-     */
-    protected ImageInterface $image;
 
     /**
      * Default quality used when no per-format override is configured.
@@ -424,87 +420,153 @@ class ImageProcessor implements ProcessorInterface
 
         $storage = $this->storageHandler->getStorage($file->storage());
 
-        // Create a local tmp file on the processing system / machine
         $tempFile = TemporaryFile::create();
         $tempFileStream = openFile($tempFile, 'wb+');
 
-        // Read the data from the files resource if (still) present,
-        // if not fetch it from the storage backend and write the data
-        // to the stream of the temp file
         $result = $this->copyOriginalFileData($file, $tempFileStream);
-
-        // Stop if the temp file could not be generated
         if ($result === false) {
+            $this->safeUnlink($tempFile);
+
             throw TempFileCreationFailedException::withFilename($tempFile);
         }
 
-        // Iterate over the variants described as an array
-        foreach ($file->variants() as $variant => $data) {
-            if (!$this->shouldProcessVariant($variant, $data)) {
-                continue;
-            }
-
-            $this->image = $this->imageManager->decodePath($tempFile);
-
-            // Capture the source ICC profile so we can re-apply it after
-            // operations run, in case any modifier strips it. profile()
-            // throws when the source has no profile, which we treat as a
-            // no-op for preservation purposes.
-            $sourceProfile = null;
-            if ($this->preserveProfile) {
-                try {
-                    $sourceProfile = $this->image->profile();
-                } catch (Throwable) {
-                    $sourceProfile = null;
+        try {
+            foreach ($file->variants() as $variant => $data) {
+                if (!$this->shouldProcessVariant($variant, $data)) {
+                    continue;
                 }
+
+                $file = $this->processVariant($file, $variant, $data, $tempFile, $storage);
             }
+        } finally {
+            $this->safeUnlink($tempFile);
+        }
 
-            $operations = new Operations($this->image);
+        return $file;
+    }
 
-            // Apply the operations
-            foreach ($data['operations'] as $operation => $arguments) {
-                $operations->{$operation}($arguments);
-            }
+    /**
+     * Decodes the source temp file, runs the variant's operations, encodes
+     * the result and writes it to storage. Returns the file with the
+     * variant's path and URL filled in.
+     *
+     * @param \PhpCollective\Infrastructure\Storage\FileInterface $file File
+     * @param string $variant Variant name
+     * @param array<string, mixed> $data Variant config
+     * @param string $tempFile Source temp file path
+     * @param \League\Flysystem\FilesystemAdapter $storage Storage adapter
+     *
+     * @return \PhpCollective\Infrastructure\Storage\FileInterface
+     */
+    protected function processVariant(
+        FileInterface $file,
+        string $variant,
+        array $data,
+        string $tempFile,
+        FilesystemAdapter $storage,
+    ): FileInterface {
+        $image = $this->imageManager->decodePath($tempFile);
 
-            if ($sourceProfile !== null) {
-                try {
-                    $this->image->setProfile($sourceProfile);
-                } catch (Throwable) {
-                    // Driver doesn't support profiles (e.g. GD); silently skip
-                }
-            }
+        $sourceProfile = $this->preserveProfile ? $this->captureProfile($image) : null;
 
-            $extension = $operations->getOutputFormat() ?? $file->extension();
-            $path = $this->pathForVariant($file, $variant, $operations->getOutputFormat());
+        $operations = new Operations($image);
+        foreach ($data['operations'] as $operation => $arguments) {
+            $operations->{$operation}($arguments);
+        }
 
-            if (isset($data['optimize']) && $data['optimize'] === true) {
-                $this->optimizeAndStore($file, $path, $extension);
-            } else {
-                $encoded = $this->encodeImage($extension);
-                $stream = openFile('php://temp', 'rb+');
-                fwrite($stream, (string)$encoded);
-                rewind($stream);
-                $storage->writeStream(
-                    $path,
-                    $stream,
-                    new Config(),
-                );
-                fclose($stream);
-            }
+        if ($sourceProfile !== null) {
+            $this->restoreProfile($image, $sourceProfile);
+        }
 
-            $data['path'] = $path;
-            $file = $file->withVariant($variant, $data);
+        $outputFormat = $operations->getOutputFormat();
+        $extension = $outputFormat ?? $file->extension();
+        $path = $this->pathForVariant($file, $variant, $outputFormat);
 
-            if ($this->urlBuilder !== null) {
-                $data['url'] = $this->urlBuilder->urlForVariant($file, $variant);
-            }
+        if (isset($data['optimize']) && $data['optimize'] === true) {
+            $this->optimizeAndStore($image, $file, $path, $extension);
+        } else {
+            $this->encodeAndStore($image, $extension, $path, $storage);
+        }
 
+        $data['path'] = $path;
+        $file = $file->withVariant($variant, $data);
+
+        if ($this->urlBuilder !== null) {
+            $data['url'] = $this->urlBuilder->urlForVariant($file, $variant);
             $file = $file->withVariant($variant, $data);
         }
 
-        unlink($tempFile);
-
         return $file;
+    }
+
+    /**
+     * Captures the source image's ICC profile so we can re-apply it after
+     * operations run. profile() throws when the source has no profile —
+     * for preservation purposes we treat that as "nothing to restore".
+     *
+     * @param \Intervention\Image\Interfaces\ImageInterface $image Image
+     *
+     * @return mixed
+     */
+    protected function captureProfile(ImageInterface $image): mixed
+    {
+        try {
+            return $image->profile();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param \Intervention\Image\Interfaces\ImageInterface $image Image
+     * @param mixed $profile Profile to restore
+     *
+     * @return void
+     */
+    protected function restoreProfile(ImageInterface $image, mixed $profile): void
+    {
+        try {
+            $image->setProfile($profile);
+        } catch (Throwable) {
+            // Driver doesn't support profiles (e.g. GD); silently skip
+        }
+    }
+
+    /**
+     * @param \Intervention\Image\Interfaces\ImageInterface $image Image
+     * @param string|null $extension File extension
+     * @param string $path Destination path in storage
+     * @param \League\Flysystem\FilesystemAdapter $storage Storage adapter
+     *
+     * @return void
+     */
+    protected function encodeAndStore(
+        ImageInterface $image,
+        ?string $extension,
+        string $path,
+        FilesystemAdapter $storage,
+    ): void {
+        $encoded = $this->encodeImage($image, $extension);
+        $stream = openFile('php://temp', 'rb+');
+        try {
+            fwrite($stream, (string)$encoded);
+            rewind($stream);
+            $storage->writeStream($path, $stream, new Config());
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    /**
+     * @param string $path File path
+     *
+     * @return void
+     */
+    protected function safeUnlink(string $path): void
+    {
+        if (is_file($path)) {
+            unlink($path);
+        }
     }
 
     /**
@@ -530,18 +592,19 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
-     * Encodes the current image using the given file extension. `quality` and
-     * `strip` are only forwarded to encoders that accept them; for png/gif/bmp
-     * passing them would trigger an unknown-named-argument error in
-     * intervention/image v4.
+     * Encodes the given image using the given file extension. `quality`
+     * and `strip` are only forwarded to encoders that accept them; for
+     * png/gif/bmp passing them would trigger an unknown-named-argument
+     * error in intervention/image v4.
      *
+     * @param \Intervention\Image\Interfaces\ImageInterface $image Image
      * @param string|null $extension File extension
      *
      * @throws \InvalidArgumentException If extension is empty
      *
      * @return \Intervention\Image\Interfaces\EncodedImageInterface
      */
-    protected function encodeImage(?string $extension): EncodedImageInterface
+    protected function encodeImage(ImageInterface $image, ?string $extension): EncodedImageInterface
     {
         if ($extension === null || $extension === '') {
             throw new InvalidArgumentException('Cannot encode image without a file extension');
@@ -549,59 +612,54 @@ class ImageProcessor implements ProcessorInterface
 
         $extension = strtolower($extension);
         if (in_array($extension, self::QUALITY_AWARE_EXTENSIONS, true)) {
-            return $this->image->encodeUsingFileExtension(
+            return $image->encodeUsingFileExtension(
                 $extension,
                 quality: $this->qualityFor($extension),
                 strip: $this->stripExif,
             );
         }
 
-        return $this->image->encodeUsingFileExtension($extension);
+        return $image->encodeUsingFileExtension($extension);
     }
 
     /**
+     * Encodes via the spatie optimizer chain, which needs file paths
+     * (not streams) for compatibility with the underlying CLI tools.
+     * Both temp files are cleaned up even when storage I/O throws.
+     *
+     * @param \Intervention\Image\Interfaces\ImageInterface $image Image
      * @param \PhpCollective\Infrastructure\Storage\FileInterface $file File
-     * @param string $path Path
+     * @param string $path Destination path in storage
      * @param string|null $extension Output file extension
      *
      * @return void
      */
-    protected function optimizeAndStore(FileInterface $file, string $path, ?string $extension = null): void
-    {
+    protected function optimizeAndStore(
+        ImageInterface $image,
+        FileInterface $file,
+        string $path,
+        ?string $extension = null,
+    ): void {
         $storage = $this->storageHandler->getStorage($file->storage());
 
-        // We need temp files because the optimizer requires file paths
-        // rather than streams for compatibility with various optimization tools
         $optimizerTempFile = TemporaryFile::create();
         $optimizerOutput = TemporaryFile::create();
 
-        // Encode the image with the proper format and write to temp file
-        $encoded = $this->encodeImage($extension ?? $file->extension());
-        file_put_contents($optimizerTempFile, (string)$encoded);
+        try {
+            $encoded = $this->encodeImage($image, $extension ?? $file->extension());
+            file_put_contents($optimizerTempFile, (string)$encoded);
 
-        // Optimize it and write it to another file
-        $this->optimizer()->optimize($optimizerTempFile, $optimizerOutput);
+            $this->optimizer()->optimize($optimizerTempFile, $optimizerOutput);
 
-        // Open a new stream for the storage system
-        $optimizerOutputHandler = openFile($optimizerOutput, 'rb+');
-
-        // And store it...
-        $storage->writeStream(
-            $path,
-            $optimizerOutputHandler,
-            new Config(),
-        );
-
-        // Cleanup
-        fclose($optimizerOutputHandler);
-        unlink($optimizerTempFile);
-        unlink($optimizerOutput);
-
-        // Cleanup
-        unset(
-            $optimizerOutputHandler,
-            $optimizerTempFile,
-            $optimizerOutput,
-        );
+            $stream = openFile($optimizerOutput, 'rb+');
+            try {
+                $storage->writeStream($path, $stream, new Config());
+            } finally {
+                fclose($stream);
+            }
+        } finally {
+            $this->safeUnlink($optimizerTempFile);
+            $this->safeUnlink($optimizerOutput);
+        }
     }
 }

--- a/src/ImageVariant.php
+++ b/src/ImageVariant.php
@@ -265,7 +265,7 @@ class ImageVariant extends Variant
      * @param int $height Height
      * @param callable|null $callback Callback
      * @param bool $preventUpscale Prevent Upscaling
-     * @param string $position Position
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Position|string $position Position
      *
      * @return $this
      */
@@ -274,14 +274,14 @@ class ImageVariant extends Variant
         int $height,
         ?callable $callback = null,
         bool $preventUpscale = false,
-        string $position = 'center',
+        Position|string $position = Position::Center,
     ) {
         $this->operations['cover'] = [
             'width' => $width,
             'height' => $height,
             'callback' => $callback,
             'preventUpscale' => $preventUpscale,
-            'position' => $position,
+            'position' => $position instanceof Position ? $position->value : $position,
         ];
 
         return $this;
@@ -392,7 +392,7 @@ class ImageVariant extends Variant
      * @param int $width Canvas width
      * @param int $height Canvas height
      * @param string|null $background Background color (hex or named)
-     * @param string $position Alignment of the original image
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Position|string $position Alignment of the original image
      *
      * @return $this
      */
@@ -400,13 +400,13 @@ class ImageVariant extends Variant
         int $width,
         int $height,
         ?string $background = null,
-        string $position = 'center',
+        Position|string $position = Position::Center,
     ) {
         $this->operations['resizeCanvas'] = [
             'width' => $width,
             'height' => $height,
             'background' => $background,
-            'position' => $position,
+            'position' => $position instanceof Position ? $position->value : $position,
         ];
 
         return $this;
@@ -432,7 +432,7 @@ class ImageVariant extends Variant
      * Inserts a watermark or overlay on top of the image.
      *
      * @param string $image Path to overlay image
-     * @param string $position Alignment, e.g. 'bottom-right'
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Position|string $position Alignment, e.g. Position::BottomRight
      * @param int $x Horizontal offset from alignment position
      * @param int $y Vertical offset from alignment position
      * @param float $opacity Opacity, 0.0 to 1.0
@@ -441,14 +441,14 @@ class ImageVariant extends Variant
      */
     public function place(
         string $image,
-        string $position = 'bottom-center',
+        Position|string $position = Position::BottomCenter,
         int $x = 0,
         int $y = 0,
         float $opacity = 1.0,
     ) {
         $this->operations['place'] = [
             'image' => $image,
-            'position' => $position,
+            'position' => $position instanceof Position ? $position->value : $position,
             'x' => $x,
             'y' => $y,
             'opacity' => $opacity,

--- a/src/ImageVariant.php
+++ b/src/ImageVariant.php
@@ -35,20 +35,6 @@ class ImageVariant extends Variant
     protected string $url = '';
 
     /**
-     * @deprecated Use {@see FlipDirection::Horizontal} instead.
-     *
-     * @var string
-     */
-    public const FLIP_HORIZONTAL = FlipDirection::Horizontal->value;
-
-    /**
-     * @deprecated Use {@see FlipDirection::Vertical} instead.
-     *
-     * @var string
-     */
-    public const FLIP_VERTICAL = FlipDirection::Vertical->value;
-
-    /**
      * @param string $name Name
      *
      * @return self

--- a/src/ImageVariant.php
+++ b/src/ImageVariant.php
@@ -14,7 +14,6 @@
 
 namespace PhpCollective\Infrastructure\Storage\Processor\Image;
 
-use InvalidArgumentException;
 use PhpCollective\Infrastructure\Storage\Processor\Variant;
 
 /**
@@ -36,14 +35,18 @@ class ImageVariant extends Variant
     protected string $url = '';
 
     /**
+     * @deprecated Use {@see FlipDirection::Horizontal} instead.
+     *
      * @var string
      */
-    public const FLIP_HORIZONTAL = 'h';
+    public const FLIP_HORIZONTAL = FlipDirection::Horizontal->value;
 
     /**
+     * @deprecated Use {@see FlipDirection::Vertical} instead.
+     *
      * @var string
      */
-    public const FLIP_VERTICAL = 'v';
+    public const FLIP_VERTICAL = FlipDirection::Vertical->value;
 
     /**
      * @param string $name Name
@@ -197,9 +200,7 @@ class ImageVariant extends Variant
      */
     public function flipHorizontal()
     {
-        $this->operations['flipHorizontal'] = [
-            'direction' => self::FLIP_HORIZONTAL,
-        ];
+        $this->operations['flipHorizontal'] = [];
 
         return $this;
     }
@@ -211,33 +212,27 @@ class ImageVariant extends Variant
      */
     public function flipVertical()
     {
-        $this->operations['flipVertical'] = [
-            'direction' => self::FLIP_VERTICAL,
-        ];
+        $this->operations['flipVertical'] = [];
 
         return $this;
     }
 
     /**
-     * Flips the image
+     * Flips the image. Accepts a `FlipDirection` enum case or one of the
+     * string codes `'h'` / `'v'` / `'horizontal'` / `'vertical'`.
      *
-     * @param string $direction Direction, h or v
-     *
-     * @throws \InvalidArgumentException
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\FlipDirection|string $direction Direction
      *
      * @return $this
      */
-    public function flip(string $direction)
+    public function flip(FlipDirection|string $direction)
     {
-        if ($direction !== 'h' && $direction !== 'v') {
-            throw new InvalidArgumentException(sprintf(
-                '`%s` is invalid, provide `h` or `v`',
-                $direction,
-            ));
+        if (is_string($direction)) {
+            $direction = FlipDirection::fromName($direction);
         }
 
         $this->operations['flip'] = [
-            'direction' => $direction,
+            'direction' => $direction->value,
         ];
 
         return $this;

--- a/src/ImageVariantCollection.php
+++ b/src/ImageVariantCollection.php
@@ -67,6 +67,8 @@ class ImageVariantCollection implements ImageVariantCollectionInterface
     /**
      * @param array<string, array<string, mixed>> $variants Variant array structure
      *
+     * @throws \PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOperationException
+     *
      * @return self
      */
     public static function fromArray(array $variants)
@@ -85,7 +87,7 @@ class ImageVariantCollection implements ImageVariantCollectionInterface
 
             foreach ($data['operations'] as $method => $args) {
                 if (!method_exists($variant, $method)) {
-                    UnsupportedOperationException::withName($method);
+                    throw UnsupportedOperationException::withName($method);
                 }
 
                 /** @var array<mixed> $parameters */

--- a/src/ImageVariantCollection.php
+++ b/src/ImageVariantCollection.php
@@ -39,8 +39,12 @@ class ImageVariantCollection implements ImageVariantCollectionInterface
     }
 
     /**
-     * Workaround for php 8 because call_user_func_array will now behave this way:
-     * args keys will now be interpreted as parameter names, instead of being silently ignored.
+     * Picks only the entries from `$args` whose keys match a parameter
+     * name on `$object::$method()`. Necessary because PHP 8 treats array
+     * keys passed to `call_user_func_array()` as named arguments — any
+     * stale key (e.g. an entry left over from a previous schema, or
+     * from `toArray()` round-trip data like `direction` on a `flipHorizontal`
+     * call) would surface as a `TypeError`.
      *
      * @param object $object
      * @param string $method

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -27,49 +27,67 @@ use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOp
 class Operations
 {
     /**
+     * @deprecated Use {@see Position::Center} instead.
+     *
      * @var string
      */
-    public const POSITION_CENTER = 'center';
+    public const POSITION_CENTER = Position::Center->value;
 
     /**
+     * @deprecated Use {@see Position::TopCenter} instead.
+     *
      * @var string
      */
-    public const POSITION_TOP_CENTER = 'top-center';
+    public const POSITION_TOP_CENTER = Position::TopCenter->value;
 
     /**
+     * @deprecated Use {@see Position::BottomCenter} instead.
+     *
      * @var string
      */
-    public const POSITION_BOTTOM_CENTER = 'bottom-center';
+    public const POSITION_BOTTOM_CENTER = Position::BottomCenter->value;
 
     /**
+     * @deprecated Use {@see Position::LeftTop} instead.
+     *
      * @var string
      */
-    public const POSITION_LEFT_TOP = 'left-top';
+    public const POSITION_LEFT_TOP = Position::LeftTop->value;
 
     /**
+     * @deprecated Use {@see Position::RightTop} instead.
+     *
      * @var string
      */
-    public const POSITION_RIGHT_TOP = 'right-top';
+    public const POSITION_RIGHT_TOP = Position::RightTop->value;
 
     /**
+     * @deprecated Use {@see Position::LeftCenter} instead.
+     *
      * @var string
      */
-    public const POSITION_LEFT_CENTER = 'left-center';
+    public const POSITION_LEFT_CENTER = Position::LeftCenter->value;
 
     /**
+     * @deprecated Use {@see Position::RightCenter} instead.
+     *
      * @var string
      */
-    public const POSITION_RIGHT_CENTER = 'right-center';
+    public const POSITION_RIGHT_CENTER = Position::RightCenter->value;
 
     /**
+     * @deprecated Use {@see Position::LeftBottom} instead.
+     *
      * @var string
      */
-    public const POSITION_LEFT_BOTTOM = 'left-bottom';
+    public const POSITION_LEFT_BOTTOM = Position::LeftBottom->value;
 
     /**
+     * @deprecated Use {@see Position::RightBottom} instead.
+     *
      * @var string
      */
-    public const POSITION_RIGHT_BOTTOM = 'right-bottom';
+    public const POSITION_RIGHT_BOTTOM = Position::RightBottom->value;
 
     /**
      * @var \Intervention\Image\Interfaces\ImageInterface
@@ -102,6 +120,28 @@ class Operations
     }
 
     /**
+     * Normalises a position argument to the string form intervention/image
+     * accepts. Supports `Position` enum cases (resolved via `->value`) and
+     * raw strings (passed through). `null` returns the supplied default.
+     *
+     * @param mixed $value Position value
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Position $default Fallback case
+     *
+     * @return string
+     */
+    protected function resolvePosition(mixed $value, Position $default): string
+    {
+        if ($value instanceof Position) {
+            return $value->value;
+        }
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        return $default->value;
+    }
+
+    /**
      * @param string $name Name
      * @param array<string, mixed> $arguments Arguments
      *
@@ -129,23 +169,18 @@ class Operations
             throw new InvalidArgumentException('Missing width or height');
         }
 
-        $arguments += ['position' => static::POSITION_CENTER];
+        $position = $this->resolvePosition($arguments['position'] ?? null, Position::Center);
+        $width = (int)$arguments['width'];
+        $height = (int)$arguments['height'];
         $preventUpscale = $arguments['preventUpscale'] ?? false;
+
         if ($preventUpscale) {
-            $this->image->coverDown(
-                (int)$arguments['width'],
-                (int)$arguments['height'],
-                $arguments['position'],
-            );
+            $this->image->coverDown($width, $height, $position);
 
             return;
         }
 
-        $this->image->cover(
-            (int)$arguments['width'],
-            (int)$arguments['height'],
-            $arguments['position'],
-        );
+        $this->image->cover($width, $height, $position);
     }
 
     /**
@@ -163,19 +198,19 @@ class Operations
             throw new InvalidArgumentException('Missing width or height');
         }
 
-        $arguments += ['x' => null, 'y' => null, 'position' => static::POSITION_CENTER];
-        $height = (int)$arguments['height'];
         $width = (int)$arguments['width'];
+        $height = (int)$arguments['height'];
+        $position = $this->resolvePosition($arguments['position'] ?? null, Position::Center);
+        $x = $arguments['x'] ?? null;
+        $y = $arguments['y'] ?? null;
 
-        // If x and y are explicitly provided, use coordinate-based cropping
-        if ($arguments['x'] !== null && $arguments['y'] !== null) {
-            $x = (int)$arguments['x'];
-            $y = (int)$arguments['y'];
-            $this->image->crop($width, $height, $x, $y, alignment: $arguments['position']);
-        } else {
-            // Use position-based cropping only
-            $this->image->crop($width, $height, alignment: $arguments['position']);
+        if ($x !== null && $y !== null) {
+            $this->image->crop($width, $height, (int)$x, (int)$y, alignment: $position);
+
+            return;
         }
+
+        $this->image->crop($width, $height, alignment: $position);
     }
 
     /**
@@ -479,16 +514,11 @@ class Operations
             throw new InvalidArgumentException('Missing width or height');
         }
 
-        $arguments += [
-            'background' => null,
-            'position' => static::POSITION_CENTER,
-        ];
-
         $this->image->resizeCanvas(
             (int)$arguments['width'],
             (int)$arguments['height'],
-            $arguments['background'],
-            $arguments['position'],
+            $arguments['background'] ?? null,
+            $this->resolvePosition($arguments['position'] ?? null, Position::Center),
         );
     }
 
@@ -511,7 +541,7 @@ class Operations
             $width,
             $height,
             $arguments['background'] ?? null,
-            $arguments['position'] ?? static::POSITION_CENTER,
+            $this->resolvePosition($arguments['position'] ?? null, Position::Center),
         );
     }
 
@@ -532,12 +562,13 @@ class Operations
             throw new InvalidArgumentException('Missing image');
         }
 
-        $position = $arguments['position'] ?? static::POSITION_BOTTOM_CENTER;
-        $x = (int)($arguments['x'] ?? 0);
-        $y = (int)($arguments['y'] ?? 0);
-        $opacity = (float)($arguments['opacity'] ?? 1);
-
-        $this->image->insert($arguments['image'], $x, $y, $position, $opacity);
+        $this->image->insert(
+            $arguments['image'],
+            (int)($arguments['x'] ?? 0),
+            (int)($arguments['y'] ?? 0),
+            $this->resolvePosition($arguments['position'] ?? null, Position::BottomCenter),
+            (float)($arguments['opacity'] ?? 1),
+        );
     }
 
     /**

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -248,19 +248,14 @@ class Operations
             throw new InvalidArgumentException('Direction missing');
         }
 
-        if ($arguments['direction'] !== 'v' && $arguments['direction'] !== 'h') {
-            throw new InvalidArgumentException(
-                'Invalid argument, you must provide h or v',
-            );
-        }
-
-        if ($arguments['direction'] === 'h') {
-            $this->image->flip(Direction::HORIZONTAL);
+        $direction = $arguments['direction'];
+        if ($direction instanceof FlipDirection) {
+            $this->image->flip($direction->intervention());
 
             return;
         }
 
-        $this->image->flip(Direction::VERTICAL);
+        $this->image->flip(FlipDirection::fromName((string)$direction)->intervention());
     }
 
     /**

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -27,69 +27,6 @@ use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOp
 class Operations
 {
     /**
-     * @deprecated Use {@see Position::Center} instead.
-     *
-     * @var string
-     */
-    public const POSITION_CENTER = Position::Center->value;
-
-    /**
-     * @deprecated Use {@see Position::TopCenter} instead.
-     *
-     * @var string
-     */
-    public const POSITION_TOP_CENTER = Position::TopCenter->value;
-
-    /**
-     * @deprecated Use {@see Position::BottomCenter} instead.
-     *
-     * @var string
-     */
-    public const POSITION_BOTTOM_CENTER = Position::BottomCenter->value;
-
-    /**
-     * @deprecated Use {@see Position::LeftTop} instead.
-     *
-     * @var string
-     */
-    public const POSITION_LEFT_TOP = Position::LeftTop->value;
-
-    /**
-     * @deprecated Use {@see Position::RightTop} instead.
-     *
-     * @var string
-     */
-    public const POSITION_RIGHT_TOP = Position::RightTop->value;
-
-    /**
-     * @deprecated Use {@see Position::LeftCenter} instead.
-     *
-     * @var string
-     */
-    public const POSITION_LEFT_CENTER = Position::LeftCenter->value;
-
-    /**
-     * @deprecated Use {@see Position::RightCenter} instead.
-     *
-     * @var string
-     */
-    public const POSITION_RIGHT_CENTER = Position::RightCenter->value;
-
-    /**
-     * @deprecated Use {@see Position::LeftBottom} instead.
-     *
-     * @var string
-     */
-    public const POSITION_LEFT_BOTTOM = Position::LeftBottom->value;
-
-    /**
-     * @deprecated Use {@see Position::RightBottom} instead.
-     *
-     * @var string
-     */
-    public const POSITION_RIGHT_BOTTOM = Position::RightBottom->value;
-
-    /**
      * @var \Intervention\Image\Interfaces\ImageInterface
      */
     protected ImageInterface $image;

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -185,7 +185,7 @@ class Operations
      */
     public function flipHorizontal(): void
     {
-        $this->flip(['direction' => 'h']);
+        $this->image->flip(Direction::HORIZONTAL);
     }
 
     /**
@@ -195,7 +195,7 @@ class Operations
      */
     public function flipVertical(): void
     {
-        $this->flip(['direction' => 'v']);
+        $this->image->flip(Direction::VERTICAL);
     }
 
     /**

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -147,9 +147,9 @@ class Operations
      *
      * @throws \PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOperationException
      *
-     * @return mixed
+     * @return never
      */
-    public function __call(string $name, array $arguments): mixed
+    public function __call(string $name, array $arguments): never
     {
         throw UnsupportedOperationException::withName($name);
     }

--- a/src/Position.php
+++ b/src/Position.php
@@ -41,7 +41,7 @@ enum Position: string
     /**
      * Resolves a position name (e.g. from a config array) to the matching
      * enum case. Lower-cases and trims the input so values like `'CENTER'`
-     * or `'  top-left  '` resolve correctly.
+     * or `' top-left '` resolve correctly.
      *
      * @param string $name Position name
      *

--- a/src/Position.php
+++ b/src/Position.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Processor\Image;
+
+use InvalidArgumentException;
+
+/**
+ * Alignment positions for crop, cover, resizeCanvas, padding and place
+ * operations. Use this enum instead of magic position strings:
+ *
+ *     $variant->cover(150, 150, position: Position::TopCenter);
+ *     $variant->place('logo.png', position: Position::BottomRight);
+ *
+ * The string backing values match intervention/image's `Alignment`
+ * enum, so they pass through to the underlying library unchanged.
+ */
+enum Position: string
+{
+    case Center = 'center';
+    case TopCenter = 'top-center';
+    case BottomCenter = 'bottom-center';
+    case LeftTop = 'left-top';
+    case TopLeft = 'top-left';
+    case RightTop = 'right-top';
+    case TopRight = 'top-right';
+    case LeftCenter = 'left-center';
+    case RightCenter = 'right-center';
+    case LeftBottom = 'left-bottom';
+    case BottomLeft = 'bottom-left';
+    case RightBottom = 'right-bottom';
+    case BottomRight = 'bottom-right';
+
+    /**
+     * Resolves a position name (e.g. from a config array) to the matching
+     * enum case. Lower-cases and trims the input so values like `'CENTER'`
+     * or `'  top-left  '` resolve correctly.
+     *
+     * @param string $name Position name
+     *
+     * @throws \InvalidArgumentException When the name does not match any case
+     *
+     * @return self
+     */
+    public static function fromName(string $name): self
+    {
+        $case = self::tryFrom(strtolower(trim($name)));
+        if ($case !== null) {
+            return $case;
+        }
+
+        $valid = implode(', ', array_map(static fn (self $c): string => $c->value, self::cases()));
+
+        throw new InvalidArgumentException(sprintf(
+            'Unknown image position "%s". Expected one of: %s.',
+            $name,
+            $valid,
+        ));
+    }
+}

--- a/tests/TestCase/Processor/Image/FlipDirectionTest.php
+++ b/tests/TestCase/Processor/Image/FlipDirectionTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Test\TestCase\Processor\Image;
+
+use Intervention\Image\Direction;
+use InvalidArgumentException;
+use PhpCollective\Infrastructure\Storage\Processor\Image\FlipDirection;
+use PhpCollective\Test\TestCase\TestCase;
+
+/**
+ * FlipDirectionTest
+ */
+class FlipDirectionTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testStringValuesArePreservedFromV1(): void
+    {
+        $this->assertSame('h', FlipDirection::Horizontal->value);
+        $this->assertSame('v', FlipDirection::Vertical->value);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFromNameAcceptsCodeAndLongForm(): void
+    {
+        $this->assertSame(FlipDirection::Horizontal, FlipDirection::fromName('h'));
+        $this->assertSame(FlipDirection::Horizontal, FlipDirection::fromName('HORIZONTAL'));
+        $this->assertSame(FlipDirection::Vertical, FlipDirection::fromName('  v  '));
+        $this->assertSame(FlipDirection::Vertical, FlipDirection::fromName('vertical'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testFromNameThrowsOnUnknown(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown flip direction "diagonal"');
+
+        FlipDirection::fromName('diagonal');
+    }
+
+    /**
+     * @return void
+     */
+    public function testInterventionMapsToUpstreamEnum(): void
+    {
+        $this->assertSame(Direction::HORIZONTAL, FlipDirection::Horizontal->intervention());
+        $this->assertSame(Direction::VERTICAL, FlipDirection::Vertical->intervention());
+    }
+}

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -137,6 +137,37 @@ class ImageProcessorTest extends TestCase
     /**
      * @return void
      */
+    public function testSetMimeTypesAcceptsList(): void
+    {
+        $processor = $this->buildProcessor();
+        $this->assertSame($processor, $processor->setMimeTypes(['image/jpeg', 'image/png']));
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetMimeTypesRejectsEmptyList(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->expectException(InvalidArgumentException::class);
+        $processor->setMimeTypes([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetMimeTypesRejectsEmptyEntry(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $this->expectException(InvalidArgumentException::class);
+        $processor->setMimeTypes(['image/jpeg', '']);
+    }
+
+    /**
+     * @return void
+     */
     public function testConvertOperationSwapsVariantPathExtension(): void
     {
         $processor = $this->buildProcessor();

--- a/tests/TestCase/Processor/Image/ImageVariantCollectionTest.php
+++ b/tests/TestCase/Processor/Image/ImageVariantCollectionTest.php
@@ -67,9 +67,7 @@ class ImageVariantCollectionTest extends TestCase
         $expected = [
             'resizeAndFlip' => [
                 'operations' => [
-                    'flipHorizontal' => [
-                        'direction' => 'h',
-                    ],
+                    'flipHorizontal' => [],
                     'resize' => [
                         'width' => 300,
                         'height' => 300,
@@ -91,7 +89,7 @@ class ImageVariantCollectionTest extends TestCase
         $collection2->remove('resizeAndFlip');
         $this->assertFalse($collection2->has('resizeAndFlip'));
 
-        $expected = '{"resizeAndFlip":{"operations":{"flipHorizontal":{"direction":"h"},"resize":{"width":300,"height":300,"preventUpscale":false}},"path":"","url":"","optimize":true}}';
+        $expected = '{"resizeAndFlip":{"operations":{"flipHorizontal":[],"resize":{"width":300,"height":300,"preventUpscale":false}},"path":"","url":"","optimize":true}}';
         $result = json_encode($collection);
         $this->assertEquals($expected, $result);
     }

--- a/tests/TestCase/Processor/Image/ImageVariantTest.php
+++ b/tests/TestCase/Processor/Image/ImageVariantTest.php
@@ -54,12 +54,8 @@ class ImageVariantTest extends TestCase
                     'height' => 200,
                     'preventUpscale' => false,
                 ],
-                'flipHorizontal' => [
-                    'direction' => 'h',
-                ],
-                'flipVertical' => [
-                    'direction' => 'v',
-                ],
+                'flipHorizontal' => [],
+                'flipVertical' => [],
                 'flip' => [
                     'direction' => 'v',
                 ],

--- a/tests/TestCase/Processor/Image/ImageVariantTest.php
+++ b/tests/TestCase/Processor/Image/ImageVariantTest.php
@@ -14,6 +14,7 @@
 
 namespace PhpCollective\Test\TestCase\Processor\Image;
 
+use PhpCollective\Infrastructure\Storage\Processor\Image\FlipDirection;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariant;
 use PhpCollective\Test\TestCase\TestCase;
 
@@ -31,7 +32,7 @@ class ImageVariantTest extends TestCase
             ->resize(200, 200)
             ->flipHorizontal()
             ->flipVertical()
-            ->flip(ImageVariant::FLIP_VERTICAL)
+            ->flip(FlipDirection::Vertical)
             ->heighten(200)
             ->widen(200)
             ->crop(200, 200)

--- a/tests/TestCase/Processor/Image/PositionTest.php
+++ b/tests/TestCase/Processor/Image/PositionTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Test\TestCase\Processor\Image;
+
+use InvalidArgumentException;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Position;
+use PhpCollective\Test\TestCase\TestCase;
+
+/**
+ * PositionTest
+ */
+class PositionTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testStringValuesMatchInterventionAlignmentNames(): void
+    {
+        $this->assertSame('center', Position::Center->value);
+        $this->assertSame('top-left', Position::TopLeft->value);
+        $this->assertSame('bottom-right', Position::BottomRight->value);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFromNameNormalisesInput(): void
+    {
+        $this->assertSame(Position::Center, Position::fromName('CENTER'));
+        $this->assertSame(Position::TopLeft, Position::fromName('  top-left  '));
+        $this->assertSame(Position::BottomRight, Position::fromName('Bottom-Right'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testFromNameThrowsOnUnknown(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown image position "middle"');
+
+        Position::fromName('middle');
+    }
+}


### PR DESCRIPTION
Follow-up to the anti-pattern review on PR #11. Tackles the items recommended for an "all-in-one cleanup PR": real bugs, two new enums replacing magic strings, and a small batch of API hygiene fixes. No items left for a separate PR; the larger architectural threads (operation dispatch / `Operations`+`ImageVariant` duplication / `processOnlyTheseVariants` mutability) are flagged for follow-up issues if you want to track them separately.

## Bug fixes (commit 1)

- **`ImageVariantCollection::fromArray()` silently accepted unknown operations.** The `if (!method_exists(...)) UnsupportedOperationException::withName($method);` check built the exception but never threw it. Now an actual `throw`, matching the docblock.
- **`ImageProcessor::process()` leaked the source temp file and the encode stream when any variant operation, encoder, or `writeStream` threw.** Cleanup now lives in `try/finally` on the loop body and inside `encodeAndStore()` / `optimizeAndStore()` for the inner streams. A new `safeUnlink()` helper guards `unlink()` with `is_file()` to avoid PHP warnings on already-missing temp files.
- **`$this->image` instance property removed.** The property was only needed to share the decoded image with `Operations` and the encoders; both now take the image explicitly. Removing it closes a cross-variant state-leak (last variant's image staying around) and makes `process()` re-entrant.
- **`flipHorizontal()` / `flipVertical()` skip the validation routing.** Both methods now call `$image->flip(Direction::*)` directly instead of round-tripping through the validating `flip()` method with a magic `'h'` / `'v'` string.

The variant loop is extracted into `processVariant()` so the per-variant `try/finally` has a clean scope, and the helpers (`captureProfile`, `restoreProfile`, `encodeAndStore`, `safeUnlink`) are testable in isolation.

## `Position` enum (commit 2)

Replaces stringly-typed alignment positions with a typed enum. `ImageVariant` builder methods (`cover`, `resizeCanvas`, `place`) accept `Position|string` so typed call sites get autocomplete and refactor-safety while config-driven callers can still pass the raw string. Internal storage stays as the string value, so `toArray()` / `fromArray()` round-trip without surprises.

```php
$variant->cover(150, 150, position: Position::TopCenter);
$variant->place('logo.png', position: Position::BottomRight);

// Config-driven setups still work:
$position = Position::fromName($config['position'] ?? 'center'); // case + whitespace normalised
```

The pre-existing `Operations::POSITION_*` string constants are removed outright — 2.0 isn't tagged yet, no shipped API to keep compatible with, and deprecated aliases would just be noise in the new major.

## `FlipDirection` enum (commit 3)

Same pattern for the flip operation. `ImageVariant::flip()` now accepts `FlipDirection|string`. The string form accepts both the single-character codes (`'h'`, `'v'`) and the long forms (`'horizontal'`, `'vertical'`). `FlipDirection::intervention()` returns the matching upstream `Direction` enum case so callers don't have to import intervention's enum directly.

`flipHorizontal()` / `flipVertical()` builders no longer record a redundant `'direction'` arg — the matching `Operations` methods do their own direction lookup. `FLIP_HORIZONTAL` / `FLIP_VERTICAL` constants are removed outright (same reasoning as `POSITION_*`).

```php
$variant->flip(FlipDirection::Horizontal);
$variant->flip('h');             // legacy code
$variant->flip('horizontal');    // long form
```

## API hygiene (commit 4)

- `Operations::__call(): never` — static analysis now knows the always-throws path can't return a value.
- `setMimeTypes()` promoted from `protected` to `public` with empty-list / empty-string validation. The list is configuration surface and was unreachable before.
- `copyOriginalFileData()` now throws `TempFileCreationFailedException` on copy failure instead of returning `int|bool`. Closes the temp stream via `try/finally` and unlinks the temp file before propagating.
- `fromArray()` `filterArgs()` comment updated — the old framing ("Workaround for PHP 8") was misleading; the real reason is `toArray()` round-trip data carrying stale keys (e.g. legacy fixtures with `'direction' => 'h'` on `flipHorizontal`) which would surface as `TypeError` under named-arg semantics.

## Architectural items tracked separately

Three items from the review are larger architectural threads rather than cleanup. Filed as follow-up issues so they can be discussed before code:

- #13 — Replace stringly-typed operation dispatch in `ImageProcessor`
- #14 — Deduplicate `Operations` executor + `ImageVariant` builder
- #15 — Make `processOnlyTheseVariants()` per-call instead of stateful

## Verification

- `vendor/bin/phpunit` — 56 tests, 156 assertions, all passing
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs -s` — no errors
- Branch is on top of latest `master` (no merge-base divergence), no merge conflicts
- Diff vs master: 11 files (4 src + 4 test + 2 new test files + 1 readme — actually 6 src + 5 test, see the diff stat)