### PR TITLE
Make process() variant filter per-call instead of stateful

### DIFF
--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -83,11 +83,6 @@ class ImageProcessor implements ProcessorInterface
     ];
 
     /**
-     * @var array<int, string>
-     */
-    protected array $processOnlyTheseVariants = [];
-
-    /**
      * @var \PhpCollective\Infrastructure\Storage\FileStorageInterface
      */
     protected FileStorageInterface $storageHandler;
@@ -356,28 +351,6 @@ class ImageProcessor implements ProcessorInterface
     }
 
     /**
-     * @param array<int, string> $variants Variants by name
-     *
-     * @return $this
-     */
-    public function processOnlyTheseVariants(array $variants)
-    {
-        $this->processOnlyTheseVariants = $variants;
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    public function processAll()
-    {
-        $this->processOnlyTheseVariants = [];
-
-        return $this;
-    }
-
-    /**
      * Copies the source file's bytes into the given temp-file stream,
      * preferring the in-memory resource on the file object when present
      * and falling back to a fresh read from storage. Closes the temp
@@ -418,26 +391,33 @@ class ImageProcessor implements ProcessorInterface
     /**
      * @param string $variant Variant name
      * @param array<string, mixed> $variantData Variant data
+     * @param array<int, string>|null $only Names to process; `null` processes everything
      *
      * @return bool
      */
-    protected function shouldProcessVariant(string $variant, array $variantData): bool
+    protected function shouldProcessVariant(string $variant, array $variantData, ?array $only): bool
     {
-        return !(
-            // Empty operations
-            empty($variantData['operations'])
-            || (
-                // Check if the operation should be processed
-                !empty($this->processOnlyTheseVariants)
-                && !in_array($variant, $this->processOnlyTheseVariants, true)
-            )
-        );
+        if (empty($variantData['operations'])) {
+            return false;
+        }
+        if ($only === null) {
+            return true;
+        }
+
+        return in_array($variant, $only, true);
     }
 
     /**
      * @inheritDoc
+     *
+     * @param \PhpCollective\Infrastructure\Storage\FileInterface $file File
+     * @param array<int, string>|null $only Optional list of variant names to
+     *     process. `null` (default) processes every variant defined on the
+     *     file. Pass an explicit list — e.g. `['thumbnail']` — to skip the
+     *     others on this single call. The filter does NOT persist across
+     *     subsequent process() invocations.
      */
-    public function process(FileInterface $file): FileInterface
+    public function process(FileInterface $file, ?array $only = null): FileInterface
     {
         if (!$this->isApplicable($file)) {
             return $file;
@@ -452,7 +432,7 @@ class ImageProcessor implements ProcessorInterface
 
         try {
             foreach ($file->variants() as $variant => $data) {
-                if (!$this->shouldProcessVariant($variant, $data)) {
+                if (!$this->shouldProcessVariant($variant, $data, $only)) {
                     continue;
                 }
 

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -387,6 +387,94 @@ class ImageProcessorTest extends TestCase
     }
 
     /**
+     * Variant filter is now a per-call argument; the default null processes
+     * every variant on the file.
+     *
+     * @return void
+     */
+    public function testProcessWithoutFilterProcessesAllVariants(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $file = FileFactory::fromDisk($this->getFixtureFile('titus.jpg'), 'local')
+            ->withUuid('aabb1100-2200-3300-4400-aabbccddeeff')
+            ->withFilename('foobar.jpg')
+            ->addToCollection('avatar')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $collection->addNew('thumbnail')->resize(100, 100);
+        $collection->addNew('hero')->resize(800, 400);
+
+        $file = $file->withVariants($collection->toArray());
+        $file = $processor->process($file);
+
+        $variants = $file->variants();
+        $this->assertNotSame('', $variants['thumbnail']['path']);
+        $this->assertNotSame('', $variants['hero']['path']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessWithFilterSkipsUnselectedVariants(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $file = FileFactory::fromDisk($this->getFixtureFile('titus.jpg'), 'local')
+            ->withUuid('aabb1100-2200-3300-4400-aabbccddeeff')
+            ->withFilename('foobar.jpg')
+            ->addToCollection('avatar')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $collection->addNew('thumbnail')->resize(100, 100);
+        $collection->addNew('hero')->resize(800, 400);
+
+        $file = $file->withVariants($collection->toArray());
+        $file = $processor->process($file, ['thumbnail']);
+
+        $variants = $file->variants();
+        $this->assertNotSame('', $variants['thumbnail']['path']);
+        $this->assertSame('', $variants['hero']['path'], 'hero variant should not have been written');
+    }
+
+    /**
+     * Filter does not persist between calls — each process() runs with
+     * exactly the filter passed to that invocation.
+     *
+     * @return void
+     */
+    public function testProcessFilterDoesNotLeakAcrossCalls(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $build = function () {
+            $file = FileFactory::fromDisk($this->getFixtureFile('titus.jpg'), 'local')
+                ->withUuid('aabb1100-2200-3300-4400-aabbccddeeff')
+                ->withFilename('foobar.jpg')
+                ->addToCollection('avatar')
+                ->belongsToModel('User', '1');
+
+            $collection = ImageVariantCollection::create();
+            $collection->addNew('thumbnail')->resize(100, 100);
+            $collection->addNew('hero')->resize(800, 400);
+
+            return $file->withVariants($collection->toArray());
+        };
+
+        // First call filters to thumbnail
+        $first = $processor->process($build(), ['thumbnail']);
+        $this->assertNotSame('', $first->variants()['thumbnail']['path']);
+        $this->assertSame('', $first->variants()['hero']['path']);
+
+        // Second call has no filter — both variants should be written
+        $second = $processor->process($build());
+        $this->assertNotSame('', $second->variants()['thumbnail']['path']);
+        $this->assertNotSame('', $second->variants()['hero']['path']);
+    }
+
+    /**
      * @return void
      */
     public function testCreateWithExplicitGdDriver(): void


### PR DESCRIPTION
Closes #15.

## Summary

`ImageProcessor::process()` now takes an optional second argument so the variant filter is scoped to a single call instead of leaking through processor state:

```php
// Old API (stateful, leaks across calls):
$processor->processOnlyTheseVariants(['thumbnail']);
$processor->process($file);
$processor->process($otherFile);  // still scoped to ['thumbnail'] — silent footgun

// New API (per-call, no leak):
$processor->process($file, ['thumbnail']);
$processor->process($otherFile);  // unfiltered, every variant runs
```

## Changes

- `process()` gains an optional `?array $only = null` argument. `null` (default) processes every variant on the file. Pass an explicit list to skip the others.
- `$processOnlyTheseVariants` property removed.
- `processOnlyTheseVariants()` and `processAll()` methods removed. 2.0 isn't tagged yet, so there's no released API to keep compatible — clean break.
- `shouldProcessVariant()` rewritten to take the filter as a parameter, eliminating the implicit dependency on processor state.

## Interface compatibility

`ProcessorInterface::process(FileInterface): FileInterface` is unchanged. PHP allows implementing classes to add optional parameters beyond the interface contract — concrete `ImageProcessor` callers gain the filter, `ProcessorInterface` callers keep working unchanged.

## Tests

- `testProcessWithoutFilterProcessesAllVariants` — `null` default writes every variant
- `testProcessWithFilterSkipsUnselectedVariants` — passing `['thumbnail']` writes only that variant
- `testProcessFilterDoesNotLeakAcrossCalls` — the actual fix: filtering one call has zero effect on the next

## Verification

- `vendor/bin/phpunit` — 59 tests, 164 assertions, all passing
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs -s` — no errors
- Branch on top of latest master, no conflicts