### PR TITLE
Document setPreserveAnimation in readme, processing docs, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `setQuality(int|array $quality)` — accepts a single int or a per-extension map, e.g. `['webp' => 80, 'jpg' => 90, 'avif' => 70]`
 - `setStripExif(bool $strip)` toggle (default `true`)
 - `setPreserveProfile(bool $preserve)` toggle (default `true`) — captures the source ICC profile and re-applies it after the operations chain so wide-gamut sources keep their intended color rendering
+- `setPreserveAnimation(bool $preserve)` toggle (default `true`) — animated GIF / WebP sources keep all frames through the pipeline. Disable to flatten to a single static frame (useful for thumbnail variants or when converting to a non-animated format)
 - `setMimeTypes(array $mimeTypes)` is now `public` with input validation
 - New first-class operations: `orient` (EXIF auto-rotate), `brightness`, `contrast`, `grayscale` (+ `greyscale` alias), `colorize`, `blur`, `pixelate`, `trim`, `resizeCanvas`, `padding`, `place` (watermark), `convert` (output format swap)
 - `ImageVariant::add(Operation $op)` primitive — attach `Operation` instances directly without going through a fluent builder method

--- a/docs/Processing-Images.md
+++ b/docs/Processing-Images.md
@@ -79,10 +79,26 @@ $imageProcessor
     ->setQuality(90)                                          // single value, all formats
     ->setQuality(['webp' => 80, 'jpg' => 90, 'avif' => 70])   // per-format map
     ->setStripExif(true)                                      // privacy + smaller files (default)
-    ->setPreserveProfile(true);                               // wide-gamut color (default)
+    ->setPreserveProfile(true)                                // wide-gamut color (default)
+    ->setPreserveAnimation(true);                             // animated GIF/WebP keep all frames (default)
 ```
 
 `setQuality()` accepts either an int (1–100, applied to every quality-aware encoder) or an array keyed by extension. `setStripExif(true)` is the default and only affects encoders that support the `strip` argument (jpg / jpeg / pjpg / webp / avif / heic / tiff / jp2). `setPreserveProfile(true)` (also the default) captures the source ICC profile after decode and re-applies it after operations run, so wide-gamut sources keep rendering correctly even if a callback strips the profile mid-pipeline.
+
+## Animated images
+
+Animated GIF and WebP sources are preserved through the pipeline by default — every frame runs through the operations chain (resize / crop / cover / etc. apply per-frame) and the encoder emits animated output. Call `setPreserveAnimation(false)` to flatten to a single static frame:
+
+```php
+// Keep all frames (default)
+$imageProcessor->process($file);
+
+// Flatten to a single frame — useful for static thumbnails or when
+// converting to a non-animated format like JPEG via `convert()`.
+$imageProcessor
+    ->setPreserveAnimation(false)
+    ->process($file);
+```
 
 ## Selecting a subset of variants
 

--- a/readme.md
+++ b/readme.md
@@ -67,9 +67,12 @@ $file = $imageProcessor->process($file);
 ```php
 $imageProcessor
     ->setQuality(['webp' => 80, 'jpg' => 90, 'avif' => 70]) // per-format
-    ->setStripExif(true)         // privacy + smaller files (default)
-    ->setPreserveProfile(true);  // keep wide-gamut color rendering (default)
+    ->setStripExif(true)            // privacy + smaller files (default)
+    ->setPreserveProfile(true)      // keep wide-gamut color rendering (default)
+    ->setPreserveAnimation(true);   // animated GIF/WebP keep all frames (default)
 ```
+
+`setPreserveAnimation(false)` flattens animated sources to a single frame — useful for static thumbnail variants or when converting to a non-animated format like JPEG.
 
 ### Processing a subset of variants
 


### PR DESCRIPTION
Tiny follow-up to #19. Deferred from that PR to avoid a conflict with #18's full readme rewrite, which has now landed.

- `readme.md`: extends the *Tuning the encoder* example with `setPreserveAnimation` and a one-line note about the off-switch
- `docs/Processing-Images.md`: same toggle in the tuning example, plus a new *Animated images* section explaining the default behaviour and when to flip the toggle
- `CHANGELOG.md` 2.0.0 entry: adds a bullet for `setPreserveAnimation` alongside the other configuration toggles

## Verification

- `vendor/bin/phpunit` — 77 tests, 212 assertions, all passing
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs -s` — no errors
- Branch on top of latest master, no merge conflicts
- Diff: 3 files, +23 / -3 (docs only)