### PR TITLE
Add prefer-lowest CI matrix slot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['8.3', '8.5']
+        prefer-lowest: ['']
+        include:
+          - php-version: '8.3'
+            prefer-lowest: 'prefer-lowest'
 
     steps:
     - uses: actions/checkout@v5
@@ -25,19 +29,41 @@ jobs:
         tools: pecl
         coverage: pcov
 
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ matrix.prefer-lowest }}-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-${{ matrix.php-version }}-
+
     - name: Composer install
-      run: composer install
+      run: |
+        if ${{ matrix.prefer-lowest == 'prefer-lowest' }}
+        then
+          composer update --prefer-lowest --prefer-stable --no-progress --prefer-dist
+          composer require --dev dereuromark/composer-prefer-lowest:dev-master
+        else
+          composer install --no-progress --prefer-dist --optimize-autoloader
+        fi
 
     - name: Run PHPUnit
       run: |
-        if [[ ${{ matrix.php-version }} == '8.3' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.3' && '${{ matrix.prefer-lowest }}' != 'prefer-lowest' ]]; then
           vendor/bin/phpunit --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
         fi
 
+    - name: Validate prefer-lowest
+      if: matrix.prefer-lowest == 'prefer-lowest'
+      run: vendor/bin/validate-prefer-lowest -m
+
     - name: Code Coverage Report
-      if: success() && matrix.php-version == '8.3'
+      if: success() && matrix.php-version == '8.3' && matrix.prefer-lowest != 'prefer-lowest'
       uses: codecov/codecov-action@v3
 
   cs-stan:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.3",
         "ext-json": "*",
         "intervention/image": "^4.0",
-        "spatie/image-optimizer": "^1.2.0"
+        "spatie/image-optimizer": "^1.8.0"
     },
     "require-dev": {
         "php-collective/file-storage": "^1.0.0",
@@ -63,6 +63,8 @@
         ],
         "stan": [
             "phpstan analyze"
-        ]
+        ],
+        "lowest": "validate-prefer-lowest",
+        "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json"
     }
 }


### PR DESCRIPTION
Adds a `prefer-lowest` slot to the CI matrix so we catch cases where the package's lowest-declared dependency versions don't actually install or test green. Pattern follows [`dereuromark/cakephp-ide-helper`](https://github.com/dereuromark/cakephp-ide-helper/blob/master/.github/workflows/ci.yml).

## What it does

- `prefer-lowest: ['']` is the matrix default; an `include:` row pins PHP 8.3 + `prefer-lowest: 'prefer-lowest'` so the slot runs once
- Composer install branches on `${{ matrix.prefer-lowest == 'prefer-lowest' }}`:
  - prefer-lowest path: `composer update --prefer-lowest --prefer-stable` + `composer require --dev dereuromark/composer-prefer-lowest:dev-master`
  - regular path: `composer install`
- New step `validate-prefer-lowest -m` runs only on the prefer-lowest slot
- Coverage upload and the `--coverage-clover` invocation are skipped on the prefer-lowest slot so the regular slot stays the source of truth
- Composer dep cache key includes both `matrix.php-version` and `matrix.prefer-lowest` so the two paths don't trash each other's cache

Composer scripts mirror the workflow:

- `composer lowest`        — runs `validate-prefer-lowest`
- `composer lowest-setup`  — installs prefer-lowest deps locally for testing the same workflow as CI

## Bug caught while wiring this up

`spatie/image-optimizer` 1.7.x triggers a PHP 8.4 deprecation:

> `Implicitly marking parameter $pathToOutput as nullable is deprecated, the explicit nullable type must be used instead` (OptimizerChain.php:64)

1.8.0 is the first release that fixes it. Bumped the minimum constraint from `^1.2.0` to `^1.8.0` — anything older would fail the prefer-lowest slot on PHP 8.3+ runtime.

## Verification

- `composer update --prefer-lowest --prefer-stable` + `vendor/bin/phpunit` — 77 tests, 154 assertions (lower count is PHPUnit 10's reporting), all passing
- `composer update --prefer-stable` + full test/stan/cs — 77 tests / 212 assertions, all green
- The prefer-lowest slot will run on this PR via the new matrix entry; first run will validate the constraint changes work

Branch on top of latest master, no merge conflicts.