### PR TITLE
Add Format enum and typed exception subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cover()` no longer accepts a `$callback` parameter (it was always ignored)
 - `flipHorizontal()` now produces an actual horizontal mirror (1.x silently produced a vertical flip due to a v3 quirk; output of pipelines using this op will change)
 - EXIF/metadata is now stripped from encoded output by default; call `setStripExif(false)` to preserve
+- Several internal throws moved into the `ImageProcessingException` hierarchy. Code catching the previous raw types may need to widen to the typed equivalents:
+  - `Driver::Auto` with neither Imagick nor GD installed now throws `DriverUnavailableException` (was a raw `RuntimeException`)
+  - `process()` failing to decode the source now throws `ImageCorruptedException` wrapping the underlying intervention exception (was the raw intervention exception itself)
+  - The encode path with a missing file extension now throws `UnsupportedFormatException` (was a raw `InvalidArgumentException`)
 
 ### Added
 
@@ -31,7 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New first-class operations: `orient` (EXIF auto-rotate), `brightness`, `contrast`, `grayscale` (+ `greyscale` alias), `colorize`, `blur`, `pixelate`, `trim`, `resizeCanvas`, `padding`, `place` (watermark), `convert` (output format swap)
 - `ImageVariant::add(Operation $op)` primitive — attach `Operation` instances directly without going through a fluent builder method
 - `OperationRegistry` is the single source of truth for which operations exist; pass a custom registry to `ImageProcessor` to add app-specific operations without forking
-- `Driver`, `Position`, `FlipDirection` enums replacing magic strings throughout the public API. Each enum has a `fromName()` method that does case/whitespace normalisation for config-driven callers
+- `Driver`, `Position`, `FlipDirection`, `Format` enums replacing magic strings throughout the public API. Each enum has a `fromName()` method that does case/whitespace normalisation for config-driven callers. `Format::fromName()` also recognises common aliases (`jpg` → `Jpeg`, `tif` → `Tiff`, `pjpeg` → `Pjpg`, `heif` → `Heic`, `j2k` / `jp2k` → `Jp2`)
+- `convert()` operation now accepts a `Format` enum case (preferred) in addition to a string
+- New typed exceptions extending `ImageProcessingException`:
+  - `ImageCorruptedException` — wraps `intervention/image` decode failures during `process()`. Catch this to handle truncated uploads / wrong-extension files / unsupported codecs uniformly
+  - `UnsupportedFormatException` — thrown by `encodeImage()` when the variant has no usable file extension; replaces the previous raw `InvalidArgumentException` at that boundary
+  - `DriverUnavailableException` — thrown by `Driver::Auto` when neither Imagick nor GD is installed; replaces the previous raw `RuntimeException`
 - Wider default MIME type allowlist: `image/avif`, `image/bmp`, `image/heic`, `image/heif`, `image/tiff`, `image/webp` on top of the existing `image/gif`/`jpg`/`jpeg`/`png`
 - Encoder allowlist for `quality:` / `strip:` named args extended to cover `pjpg`/`pjpeg`/`heif`/`tif`/`jp2`/`j2k`
 

--- a/docs/Available-Operations.md
+++ b/docs/Available-Operations.md
@@ -208,14 +208,19 @@ $collection->addNew('watermarked')
 
 ## Format / output
 
-### `convert(string $format)`
+### `convert(Format|string $format)`
 
-Re-encode the variant in a different format than the source. The variant's stored path's extension is swapped to match.
+Re-encode the variant in a different format than the source. The variant's stored path's extension is swapped to match. Accepts the `Format` enum (preferred — type-safe) or an extension string for config-driven setups; aliases like `jpg` / `tif` / `pjpeg` / `heif` resolve to their canonical case.
 
 ```php
+use PhpCollective\Infrastructure\Storage\Processor\Image\Format;
+
 $collection->addNew('webp-version')
     ->scale(1200, 800)
-    ->convert('webp');
+    ->convert(Format::Webp);
+
+// Config-driven
+$collection->addNew('config-driven')->convert($config['format'] ?? 'webp');
 ```
 
 ### `optimize()`

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ composer require php-collective/file-storage-image-processor
 
 ```php
 use PhpCollective\Infrastructure\Storage\Processor\Image\Driver;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Format;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariantCollection;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Position;
@@ -53,10 +54,10 @@ $collection->addNew('avatar')
     ->cover(150, 150, Position::TopCenter)
     ->optimize();
 
-// Re-encode a JPEG source as WebP
+// Re-encode a JPEG source as WebP — Format enum or string both work
 $collection->addNew('webp')
     ->scale(800, 600)
-    ->convert('webp');
+    ->convert(Format::Webp);
 
 $file = $file->withVariants($collection->toArray());
 $file = $imageProcessor->process($file);

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -14,7 +14,7 @@ use Intervention\Image\Drivers\Gd\Driver as InterventionGdDriver;
 use Intervention\Image\Drivers\Imagick\Driver as InterventionImagickDriver;
 use Intervention\Image\Interfaces\DriverInterface;
 use InvalidArgumentException;
-use RuntimeException;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\DriverUnavailableException;
 
 /**
  * Identifies which intervention/image driver `ImageProcessor::create()`
@@ -88,7 +88,7 @@ enum Driver: string
     }
 
     /**
-     * @throws \RuntimeException
+     * @throws \PhpCollective\Infrastructure\Storage\Processor\Image\Exception\DriverUnavailableException
      *
      * @return \Intervention\Image\Interfaces\DriverInterface
      */
@@ -101,9 +101,6 @@ enum Driver: string
             return new InterventionGdDriver();
         }
 
-        throw new RuntimeException(
-            'Neither the Imagick nor the GD PHP extension is available; '
-            . 'install one or pass a configured ImageManager to the constructor instead.',
-        );
+        throw DriverUnavailableException::autoDetectFailed();
     }
 }

--- a/src/Exception/DriverUnavailableException.php
+++ b/src/Exception/DriverUnavailableException.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Processor\Image\Exception;
+
+/**
+ * Thrown when `Driver::Auto` is requested but neither the Imagick nor
+ * the GD PHP extension is available on the host. Install one of them
+ * or pass an explicit `Driver::Gd` / `Driver::Imagick` (which then
+ * fails with the underlying intervention/image error if the chosen
+ * extension is missing).
+ */
+class DriverUnavailableException extends ImageProcessingException
+{
+    /**
+     * @return self
+     */
+    public static function autoDetectFailed(): self
+    {
+        return new self(
+            'Neither the Imagick nor the GD PHP extension is available; '
+            . 'install one or pass a configured ImageManager to the constructor instead.',
+        );
+    }
+}

--- a/src/Exception/ImageCorruptedException.php
+++ b/src/Exception/ImageCorruptedException.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Processor\Image\Exception;
+
+use Throwable;
+
+/**
+ * Thrown when intervention/image fails to decode the source file
+ * during `process()`. The most common causes are: a truncated upload,
+ * a file with the wrong extension for its real format, or a format
+ * the active driver cannot decode.
+ */
+class ImageCorruptedException extends ImageProcessingException
+{
+    /**
+     * @param string $path Source file path that failed to decode
+     * @param \Throwable $previous Underlying decode exception
+     *
+     * @return self
+     */
+    public static function withPath(string $path, Throwable $previous): self
+    {
+        return new self(
+            sprintf('Failed to decode image at `%s`: %s', $path, $previous->getMessage()),
+            0,
+            $previous,
+        );
+    }
+}

--- a/src/Exception/UnsupportedFormatException.php
+++ b/src/Exception/UnsupportedFormatException.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Processor\Image\Exception;
+
+/**
+ * Thrown when the processor cannot determine an output format for a
+ * variant — for example when the source file has no extension, or
+ * when an extension cannot be encoded by the active driver.
+ */
+class UnsupportedFormatException extends ImageProcessingException
+{
+    /**
+     * @return self
+     */
+    public static function missingExtension(): self
+    {
+        return new self('Cannot encode image without a file extension');
+    }
+
+    /**
+     * @param string $extension Extension string that has no encoder
+     *
+     * @return self
+     */
+    public static function withExtension(string $extension): self
+    {
+        return new self(sprintf('No encoder available for extension `%s`', $extension));
+    }
+}

--- a/src/Format.php
+++ b/src/Format.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Processor\Image;
+
+use InvalidArgumentException;
+
+/**
+ * Image output formats supported by the processor — the format an
+ * encoder produces, as opposed to a single file extension. Use this
+ * enum instead of magic strings on `convert()` and quality maps:
+ *
+ *     $variant->convert(Format::Webp);
+ *     $processor->setQuality([Format::Webp->value => 80, Format::Jpeg->value => 90]);
+ *
+ * Backed by canonical file extensions (`webp`, `jpeg`, `avif`, …)
+ * so existing config-driven setups (`'convert' => ['format' => 'webp']`)
+ * resolve correctly.
+ */
+enum Format: string
+{
+    case Jpeg = 'jpeg';
+    case Png = 'png';
+    case Gif = 'gif';
+    case Webp = 'webp';
+    case Avif = 'avif';
+    case Heic = 'heic';
+    case Tiff = 'tiff';
+    case Bmp = 'bmp';
+    case Jp2 = 'jp2';
+    case Pjpg = 'pjpg';
+
+    /**
+     * Resolves an extension or format name to the matching enum case.
+     * Lower-cases and trims the input. Recognises common aliases:
+     * `jpg` → `Jpeg`, `tif` → `Tiff`, `pjpeg` → `Pjpg`, `heif` → `Heic`,
+     * `j2k` → `Jp2`. Throws when the input does not match any case.
+     *
+     * @param string $name Extension or format name
+     *
+     * @throws \InvalidArgumentException When the name does not match any case
+     *
+     * @return self
+     */
+    public static function fromName(string $name): self
+    {
+        $normalized = strtolower(trim($name));
+
+        $aliases = [
+            'jpg' => self::Jpeg,
+            'tif' => self::Tiff,
+            'pjpeg' => self::Pjpg,
+            'heif' => self::Heic,
+            'j2k' => self::Jp2,
+            'jp2k' => self::Jp2,
+        ];
+        if (isset($aliases[$normalized])) {
+            return $aliases[$normalized];
+        }
+
+        $case = self::tryFrom($normalized);
+        if ($case !== null) {
+            return $case;
+        }
+
+        $valid = implode(', ', array_map(static fn (self $c): string => $c->value, self::cases()));
+
+        throw new InvalidArgumentException(sprintf(
+            'Unknown image format "%s". Expected one of: %s.',
+            $name,
+            $valid,
+        ));
+    }
+}

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -23,7 +23,9 @@ use League\Flysystem\FilesystemAdapter;
 use PhpCollective\Infrastructure\Storage\FileInterface;
 use PhpCollective\Infrastructure\Storage\FileStorageInterface;
 use PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilderInterface;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\ImageCorruptedException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\TempFileCreationFailedException;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedFormatException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Operation\OperationContext;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Operation\OperationRegistry;
 use PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface;
@@ -510,7 +512,11 @@ class ImageProcessor implements ProcessorInterface
         string $tempFile,
         FilesystemAdapter $storage,
     ): FileInterface {
-        $image = $this->imageManager->decodePath($tempFile);
+        try {
+            $image = $this->imageManager->decodePath($tempFile);
+        } catch (Throwable $decodeError) {
+            throw ImageCorruptedException::withPath($tempFile, $decodeError);
+        }
 
         if (!$this->preserveAnimation && $image->isAnimated()) {
             $image->removeAnimation();
@@ -649,14 +655,14 @@ class ImageProcessor implements ProcessorInterface
      * @param \Intervention\Image\Interfaces\ImageInterface $image Image
      * @param string|null $extension File extension
      *
-     * @throws \InvalidArgumentException If extension is empty
+     * @throws \PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedFormatException If extension is empty
      *
      * @return \Intervention\Image\Interfaces\EncodedImageInterface
      */
     protected function encodeImage(ImageInterface $image, ?string $extension): EncodedImageInterface
     {
         if ($extension === null || $extension === '') {
-            throw new InvalidArgumentException('Cannot encode image without a file extension');
+            throw UnsupportedFormatException::missingExtension();
         }
 
         $extension = strtolower($extension);

--- a/src/ImageVariant.php
+++ b/src/ImageVariant.php
@@ -426,13 +426,19 @@ class ImageVariant extends Variant
 
     /**
      * Re-encode the variant in a different format than the source.
+     * Pass a `Format` enum case (preferred — type-safe) or an
+     * equivalent extension string for config-driven setups.
      *
-     * @param string $format Target file extension, e.g. 'webp'
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Format|string $format Target output format
      *
      * @return $this
      */
-    public function convert(string $format)
+    public function convert(Format|string $format)
     {
+        if (is_string($format)) {
+            $format = Format::fromName($format);
+        }
+
         $this->add(new Convert($format));
 
         return $this;

--- a/src/Operation/Convert.php
+++ b/src/Operation/Convert.php
@@ -10,6 +10,8 @@
 
 namespace PhpCollective\Infrastructure\Storage\Processor\Image\Operation;
 
+use PhpCollective\Infrastructure\Storage\Processor\Image\Format;
+
 /**
  * Re-encode the variant in a different format than the source. Sets
  * the output format on the context; the processor reads it back and
@@ -18,9 +20,9 @@ namespace PhpCollective\Infrastructure\Storage\Processor\Image\Operation;
 final class Convert implements Operation
 {
     /**
-     * @param string $format Target file extension, e.g. 'webp'
+     * @param \PhpCollective\Infrastructure\Storage\Processor\Image\Format $format Target output format
      */
-    public function __construct(public readonly string $format)
+    public function __construct(public readonly Format $format)
     {
     }
 
@@ -31,11 +33,11 @@ final class Convert implements Operation
 
     public function apply(OperationContext $context): void
     {
-        $context->outputFormat = strtolower($this->format);
+        $context->outputFormat = $this->format->value;
     }
 
     public function toArray(): array
     {
-        return ['format' => $this->format];
+        return ['format' => $this->format->value];
     }
 }

--- a/src/Operation/OperationRegistry.php
+++ b/src/Operation/OperationRegistry.php
@@ -14,6 +14,7 @@ use Closure;
 use InvalidArgumentException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOperationException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\FlipDirection;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Format;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Position;
 
 /**
@@ -120,7 +121,7 @@ class OperationRegistry
                 y: (int)($a['y'] ?? 0),
                 opacity: (float)($a['opacity'] ?? 1),
             ))
-            ->register('convert', static fn (array $a): Operation => new Convert((string)$a['format']))
+            ->register('convert', static fn (array $a): Operation => new Convert(self::resolveFormat($a['format'])))
             ->register('callback', static function (array $a): Operation {
                 if (!isset($a['callback']) || !$a['callback'] instanceof Closure) {
                     throw new InvalidArgumentException('Missing or non-Closure callback argument');
@@ -216,5 +217,19 @@ class OperationRegistry
         }
 
         return FlipDirection::fromName((string)$value);
+    }
+
+    /**
+     * @param mixed $value Format enum case or extension string
+     *
+     * @return \PhpCollective\Infrastructure\Storage\Processor\Image\Format
+     */
+    protected static function resolveFormat(mixed $value): Format
+    {
+        if ($value instanceof Format) {
+            return $value;
+        }
+
+        return Format::fromName((string)$value);
     }
 }

--- a/tests/TestCase/Processor/Image/FormatTest.php
+++ b/tests/TestCase/Processor/Image/FormatTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @author Mark Scherer
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Test\TestCase\Processor\Image;
+
+use InvalidArgumentException;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Format;
+use PhpCollective\Test\TestCase\TestCase;
+
+/**
+ * FormatTest
+ */
+class FormatTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testStringValuesMatchCanonicalExtensions(): void
+    {
+        $this->assertSame('jpeg', Format::Jpeg->value);
+        $this->assertSame('webp', Format::Webp->value);
+        $this->assertSame('avif', Format::Avif->value);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFromNameAcceptsCanonicalNames(): void
+    {
+        $this->assertSame(Format::Webp, Format::fromName('webp'));
+        $this->assertSame(Format::Jpeg, Format::fromName('JPEG'));
+        $this->assertSame(Format::Avif, Format::fromName('  avif  '));
+    }
+
+    /**
+     * @return void
+     */
+    public function testFromNameAcceptsAliases(): void
+    {
+        $this->assertSame(Format::Jpeg, Format::fromName('jpg'));
+        $this->assertSame(Format::Tiff, Format::fromName('tif'));
+        $this->assertSame(Format::Pjpg, Format::fromName('pjpeg'));
+        $this->assertSame(Format::Heic, Format::fromName('heif'));
+        $this->assertSame(Format::Jp2, Format::fromName('j2k'));
+        $this->assertSame(Format::Jp2, Format::fromName('jp2k'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testFromNameThrowsOnUnknown(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown image format "vips"');
+
+        Format::fromName('vips');
+    }
+}

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -28,6 +28,7 @@ use PhpCollective\Infrastructure\Storage\FileFactory;
 use PhpCollective\Infrastructure\Storage\FileStorageInterface;
 use PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilder;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Driver as ImageDriver;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\ImageCorruptedException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariantCollection;
 use PhpCollective\Test\TestCase\TestCase;
@@ -844,5 +845,37 @@ class ImageProcessorTest extends TestCase
         $this->assertNotSame('', $captured, 'Encoded variant was not captured');
 
         return $captured;
+    }
+
+    /**
+     * Feeds a corrupt JPEG into the processor and expects the
+     * intervention/image decode failure to be wrapped in our
+     * ImageCorruptedException.
+     *
+     * @return void
+     */
+    public function testCorruptImageThrowsImageCorruptedException(): void
+    {
+        $corruptPath = sys_get_temp_dir() . '/' . uniqid('corrupt_', true) . '.jpg';
+        file_put_contents($corruptPath, 'this is not a jpeg');
+
+        try {
+            $processor = $this->buildProcessor();
+
+            $file = FileFactory::fromDisk($corruptPath, 'local')
+                ->withUuid('aabbccdd-1234-5678-9abc-def012345678')
+                ->withFilename('corrupt.jpg')
+                ->addToCollection('test')
+                ->belongsToModel('User', '1');
+
+            $collection = ImageVariantCollection::create();
+            $collection->addNew('thumb')->resize(32, 32);
+            $file = $file->withVariants($collection->toArray());
+
+            $this->expectException(ImageCorruptedException::class);
+            $processor->process($file);
+        } finally {
+            @unlink($corruptPath);
+        }
     }
 }

--- a/tests/TestCase/Processor/Image/Operation/OperationTest.php
+++ b/tests/TestCase/Processor/Image/Operation/OperationTest.php
@@ -13,6 +13,7 @@ namespace PhpCollective\Test\TestCase\Processor\Image\Operation;
 use Intervention\Image\Direction;
 use Intervention\Image\Interfaces\ImageInterface;
 use PhpCollective\Infrastructure\Storage\Processor\Image\FlipDirection;
+use PhpCollective\Infrastructure\Storage\Processor\Image\Format;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Operation\Blur;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Operation\Brightness;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Operation\Callback;
@@ -324,7 +325,7 @@ class OperationTest extends TestCase
         $context = new OperationContext($image);
 
         $this->assertNull($context->outputFormat);
-        (new Convert('WEBP'))->apply($context);
+        (new Convert(Format::Webp))->apply($context);
         $this->assertSame('webp', $context->outputFormat);
     }
 


### PR DESCRIPTION
Two BC-relevant cleanups from #4 packaged together — both are small enough to share a PR and both close BC windows that would be expensive to retrofit in 2.x.

## Format enum

Same pattern as Driver / Position / FlipDirection. The `convert` operation was the last place magic strings leaked into the public API.

```php
use PhpCollective\Infrastructure\Storage\Processor\Image\Format;

$variant->convert(Format::Webp);                  // typed (preferred)
$variant->convert($config['format'] ?? 'webp');   // string fallback
```

`ImageVariant::convert()` and the registry's `convert` factory both accept `Format|string`. `Format::fromName()` recognises the obvious aliases (`jpg` → `Jpeg`, `tif` → `Tiff`, `pjpeg` → `Pjpg`, `heif` → `Heic`, `j2k` / `jp2k` → `Jp2`) so existing config-driven setups with non-canonical names keep resolving.

## Typed exception subclasses

Three new classes, all extending `ImageProcessingException` so callers can settle on a uniform `catch (ImageProcessingException $e)`:

| Class | Replaces |
|-------|----------|
| `ImageCorruptedException` | Raw intervention/image decode exception out of `process()` |
| `UnsupportedFormatException` | Raw `InvalidArgumentException` thrown when the encoder has no file extension |
| `DriverUnavailableException` | Raw `RuntimeException` thrown by `Driver::Auto` with no Imagick / GD available |

The decode wrap is the meaningful one — `process()` now catches anything intervention raises during `decodePath()` and rethrows as `ImageCorruptedException` carrying the underlying exception as `previous`. Apps catching truncated uploads / wrong-extension files / unsupported codecs no longer need to know intervention's exception class names.

## Why ship both now

Magic-string `convert(string)` and raw exception types are both **structural** signatures — tightening them later means widening user code's catch blocks and method signatures. 2.0 is the only cheap moment to flip them; deferring would mean either dragging the magic strings into 2.x permanently or shipping another major.

## Verification

- `vendor/bin/phpunit` — 82 tests, 227 assertions, all passing
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs -s` — no errors
- Branch on top of latest master, no conflicts
- Diff: 4 new files (Format enum + 3 exceptions), 4 new tests, 8 touched files; +350 / -23

## CHANGELOG / docs

- CHANGELOG 2.0 entry: Format added to the enum list, exception subclasses listed under Added, exception-hierarchy shifts called out under Breaking
- readme.md: `convert(Format::Webp)` in the Quick Example
- docs/Available-Operations.md: `convert(Format|string $format)` section refreshed with both call styles