### PR TITLE
Fix release-readiness gaps before 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        extensions: mbstring, json, fileinfo
+        extensions: mbstring, json, fileinfo, imagick
         tools: pecl
         coverage: pcov
 
@@ -77,7 +77,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.3'
-        extensions: mbstring, json, fileinfo
+        extensions: mbstring, json, fileinfo, imagick
         coverage: none
         tools: pecl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PHP 8.3+** required (was 8.1)
 - **Intervention Image v4** required (was v3)
 - `processOnlyTheseVariants()` and `processAll()` removed; the variant filter is now a per-call argument: `$processor->process($file, ['thumbnail'])`
-- `Operations` class is gone — operations are now individual classes under `src/Operation/` resolved via `OperationRegistry`. The on-disk variant array shape is unchanged
+- `Operations` class is gone — operations are now individual classes under `src/Operation/` resolved via `OperationRegistry`. Existing single-operation entries keep the same serialized shape; repeated operations of the same name are now serialized as ordered lists
 - `Operations::POSITION_*` string constants replaced by the `Position` enum (`Position::Center`, `Position::TopCenter`, …)
 - `ImageVariant::FLIP_HORIZONTAL` / `FLIP_VERTICAL` constants replaced by the `FlipDirection` enum
 - `flip()` no longer accepts arbitrary strings — use `FlipDirection` or one of `'h'`/`'v'`/`'horizontal'`/`'vertical'`
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `heighten()` and `widen()` builders had no matching executor in the old `Operations` class — they would have thrown `UnsupportedOperationException` at runtime. Both now have working operation classes
 - `flipHorizontal()` mirrors horizontally instead of vertically (see Breaking)
 - `$this->image` is no longer kept as instance state on `ImageProcessor`, so `process()` is now safely re-entrant and doesn't leak the last variant's image to anything that touches the processor afterwards
+- Repeating the same operation type on a variant no longer overwrites the earlier step. Repeated operations are preserved and executed in insertion order
+- `ImageVariantCollection::fromArray()` now preserves serialized variant URLs in addition to paths and operations
+- `convert()` now appends the requested extension when the source variant path has no extension to replace
+- CI now installs `imagick`, so the Imagick-specific ICC, animation, and driver-selection tests run instead of being skipped
 
 ### Removed
 

--- a/docs/Processing-Images.md
+++ b/docs/Processing-Images.md
@@ -61,6 +61,11 @@ $collection->addNew('resizeAndFlip')
 $collection->addNew('crop')
     ->crop(100, 100);
 
+// Repeating the same operation type keeps both steps in order
+$collection->addNew('effects')
+    ->blur(1)
+    ->blur(6);
+
 $file = $file->withVariants($collection->toArray());
 
 // Process ALL variants (default)
@@ -113,3 +118,22 @@ $file = $imageProcessor->process($file);
 ```
 
 The filter is **per-call** — there's no leakage between invocations, so it's safe to share an `ImageProcessor` instance across requests / queue workers.
+
+## Variant serialization
+
+`ImageVariantCollection::toArray()` preserves operation order, including repeated operations of the same name. Single operations keep the legacy shape:
+
+```php
+'resize' => ['width' => 300, 'height' => 300]
+```
+
+If the same operation is added more than once, that entry becomes a list:
+
+```php
+'blur' => [
+    ['level' => 1],
+    ['level' => 6],
+]
+```
+
+`ImageVariantCollection::fromArray()` accepts both shapes and rebuilds the variant chain in the same order.

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Built on top of [Intervention Image v4](https://image.intervention.io/v4).
 * Pluggable operation registry — add custom operations without forking
 * Optional file-size optimization via [spatie/image-optimizer](https://github.com/spatie/image-optimizer)
 * Works with League Flysystem for flexible storage backends
-* Fluent API for chaining operations
+* Fluent API for chaining operations, including repeating the same operation type multiple times
 
 ## Requirements
 
@@ -59,6 +59,11 @@ $collection->addNew('webp')
     ->scale(800, 600)
     ->convert(Format::Webp);
 
+// Repeat the same operation type without losing earlier steps
+$collection->addNew('effects')
+    ->blur(1)
+    ->blur(6);
+
 $file = $file->withVariants($collection->toArray());
 $file = $imageProcessor->process($file);
 ```
@@ -93,6 +98,8 @@ $registry = OperationRegistry::default()
 
 $processor = new ImageProcessor($storage, $pathBuilder, $imageManager, urlBuilder: null, operationRegistry: $registry);
 ```
+
+Repeated operations of the same name are preserved in order when you serialize variants with `toArray()` and rebuild them later with `ImageVariantCollection::fromArray()`.
 
 ## Documentation
 

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -32,6 +32,7 @@ use PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface;
 use PhpCollective\Infrastructure\Storage\UrlBuilder\UrlBuilderInterface;
 use PhpCollective\Infrastructure\Storage\Utility\TemporaryFile;
 use Throwable;
+use function is_array;
 use function PhpCollective\Infrastructure\Storage\openFile;
 
 /**
@@ -526,7 +527,9 @@ class ImageProcessor implements ProcessorInterface
 
         $context = new OperationContext($image);
         foreach ($data['operations'] as $operation => $arguments) {
-            $this->operationRegistry->resolve($operation, $arguments)->apply($context);
+            foreach ($this->normalizeOperationPayloads($arguments) as $payload) {
+                $this->operationRegistry->resolve($operation, $payload)->apply($context);
+            }
         }
 
         if ($sourceProfile !== null) {
@@ -643,7 +646,32 @@ class ImageProcessor implements ProcessorInterface
             return $path;
         }
 
-        return preg_replace('/\.[^.\/\\\]+$/', '.' . $outputFormat, $path) ?? $path;
+        $replacedPath = preg_replace('/\.[^.\/\\\]+$/', '.' . $outputFormat, $path);
+        if ($replacedPath !== null && $replacedPath !== $path) {
+            return $replacedPath;
+        }
+
+        return $path . '.' . $outputFormat;
+    }
+
+    /**
+     * @param mixed $arguments Serialized operation payload for one method
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function normalizeOperationPayloads(mixed $arguments): array
+    {
+        if (!is_array($arguments)) {
+            return [[]];
+        }
+        if ($arguments === []) {
+            return [[]];
+        }
+        if (array_is_list($arguments) && is_array($arguments[0] ?? null)) {
+            return $arguments;
+        }
+
+        return [$arguments];
     }
 
     /**

--- a/src/ImageVariant.php
+++ b/src/ImageVariant.php
@@ -57,7 +57,18 @@ class ImageVariant extends Variant
     protected string $name;
 
     /**
-     * @var array<string, array<string, mixed>>
+     * Single operations keep the legacy shape:
+     *
+     *     'resize' => ['width' => 300, 'height' => 300]
+     *
+     * Repeated operations of the same name are stored as a list:
+     *
+     *     'blur' => [
+     *         ['level' => 1],
+     *         ['level' => 9],
+     *     ]
+     *
+     * @var array<string, array<string, mixed>|array<int, array<string, mixed>>>
      */
     protected array $operations = [];
 
@@ -104,9 +115,40 @@ class ImageVariant extends Variant
      */
     public function add(Operation $operation)
     {
-        $this->operations[$operation->name()] = $operation->toArray();
+        $name = $operation->name();
+        $serialized = $operation->toArray();
+
+        if (!isset($this->operations[$name])) {
+            $this->operations[$name] = $serialized;
+
+            return $this;
+        }
+
+        $existing = $this->operations[$name];
+        if ($this->isOperationSequence($existing)) {
+            $existing[] = $serialized;
+            $this->operations[$name] = $existing;
+
+            return $this;
+        }
+
+        $this->operations[$name] = [$existing, $serialized];
 
         return $this;
+    }
+
+    /**
+     * @param array<string, mixed>|array<int, array<string, mixed>> $value Serialized operation entry
+     *
+     * @return bool
+     */
+    protected function isOperationSequence(array $value): bool
+    {
+        if ($value === []) {
+            return false;
+        }
+
+        return array_is_list($value) && is_array($value[0] ?? null);
     }
 
     /**

--- a/src/ImageVariantCollection.php
+++ b/src/ImageVariantCollection.php
@@ -19,6 +19,7 @@ use Iterator;
 use PhpCollective\Infrastructure\Storage\Processor\Exception\VariantExistsException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOperationException;
 use ReflectionClass;
+use function is_array;
 
 /**
  * Conversion Collection
@@ -88,26 +89,51 @@ class ImageVariantCollection implements ImageVariantCollectionInterface
             if (!empty($data['path']) && is_string($data['path'])) {
                 $variant = $variant->withPath($data['path']);
             }
+            if (!empty($data['url']) && is_string($data['url'])) {
+                $variant = $variant->withUrl($data['url']);
+            }
 
             foreach ($data['operations'] as $method => $args) {
                 if (!method_exists($variant, $method)) {
                     throw UnsupportedOperationException::withName($method);
                 }
 
-                /** @var array<mixed> $parameters */
-                $parameters = self::filterArgs($variant, $method, $args);
-                /** @var callable $callable */
-                $callable = [$variant, $method];
-                $variant = call_user_func_array(
-                    $callable,
-                    $parameters,
-                );
+                foreach (self::normalizeOperationPayloads($args) as $payload) {
+                    /** @var array<mixed> $parameters */
+                    $parameters = self::filterArgs($variant, $method, $payload);
+                    /** @var callable $callable */
+                    $callable = [$variant, $method];
+                    $variant = call_user_func_array(
+                        $callable,
+                        $parameters,
+                    );
+                }
             }
 
             $that->add($variant);
         }
 
         return $that;
+    }
+
+    /**
+     * @param mixed $args Serialized operation payload for one method
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected static function normalizeOperationPayloads(mixed $args): array
+    {
+        if (!is_array($args)) {
+            return [[]];
+        }
+        if ($args === []) {
+            return [[]];
+        }
+        if (array_is_list($args) && is_array($args[0] ?? null)) {
+            return $args;
+        }
+
+        return [$args];
     }
 
     /**

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -198,6 +198,75 @@ class ImageProcessorTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testConvertOperationAppendsVariantPathExtensionForExtensionlessSource(): void
+    {
+        $processor = $this->buildProcessor();
+
+        $file = FileFactory::fromDisk($this->getFixtureFile('titus.jpg'), 'local')
+            ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973')
+            ->withFilename('foobar')
+            ->addToCollection('avatar')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $collection
+            ->addNew('asWebp')
+            ->resize(100, 100)
+            ->convert('webp');
+
+        $file = $file->withVariants($collection->toArray());
+        $file = $processor->process($file);
+
+        $variants = $file->variants();
+        $this->assertArrayHasKey('asWebp', $variants);
+        $this->assertStringEndsWith('.webp', $variants['asWebp']['path']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessAppliesRepeatedOperationsInOrder(): void
+    {
+        $applied = [];
+        $storage = $this->createMock(FilesystemAdapter::class);
+        $storage->method('writeStream')
+            ->willReturnCallback(static function (): void {
+            });
+
+        $fileStorage = $this->createMock(FileStorageInterface::class);
+        $fileStorage->method('getStorage')->willReturn($storage);
+
+        $processor = new ImageProcessor(
+            $fileStorage,
+            new PathBuilder(),
+            new ImageManager(new Driver()),
+        );
+
+        $file = FileFactory::fromDisk($this->getFixtureFile('titus.jpg'), 'local')
+            ->withUuid('aabb1100-2200-3300-4400-aabbccddeeff')
+            ->withFilename('foobar.jpg')
+            ->addToCollection('avatar')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $collection
+            ->addNew('thumbnail')
+            ->callback(function ($image) use (&$applied): void {
+                $applied[] = 'first';
+            })
+            ->callback(function ($image) use (&$applied): void {
+                $applied[] = 'second';
+            });
+
+        $file = $file->withVariants($collection->toArray());
+        $processor->process($file);
+
+        $this->assertSame(['first', 'second'], $applied);
+    }
+
+    /**
      * Builds a JPEG fixture with an embedded ICC profile and runs it through
      * the processor with profile preservation enabled. The encoded variant
      * bytes are captured from the storage adapter and re-decoded so the

--- a/tests/TestCase/Processor/Image/ImageVariantCollectionTest.php
+++ b/tests/TestCase/Processor/Image/ImageVariantCollectionTest.php
@@ -93,4 +93,28 @@ class ImageVariantCollectionTest extends TestCase
         $result = json_encode($collection);
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @return void
+     */
+    public function testFromArrayPreservesUrlAndRepeatedOperations(): void
+    {
+        $expected = [
+            'effects' => [
+                'operations' => [
+                    'blur' => [
+                        ['level' => 1],
+                        ['level' => 9],
+                    ],
+                ],
+                'path' => '/variants/effects.webp',
+                'url' => 'https://cdn.example.test/variants/effects.webp',
+                'optimize' => false,
+            ],
+        ];
+
+        $collection = ImageVariantCollection::fromArray($expected);
+
+        $this->assertEquals($expected, $collection->toArray());
+    }
 }

--- a/tests/TestCase/Processor/Image/ImageVariantTest.php
+++ b/tests/TestCase/Processor/Image/ImageVariantTest.php
@@ -96,4 +96,26 @@ class ImageVariantTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @return void
+     */
+    public function testVariantPreservesRepeatedOperations(): void
+    {
+        $variant = ImageVariant::create('effects')
+            ->blur(1)
+            ->blur(9);
+
+        $this->assertSame([
+            'operations' => [
+                'blur' => [
+                    ['level' => 1],
+                    ['level' => 9],
+                ],
+            ],
+            'path' => '',
+            'url' => '',
+            'optimize' => false,
+        ], $variant->toArray());
+    }
 }


### PR DESCRIPTION
## Summary

Tightens the package before the 2.0 release by fixing four release-readiness gaps found in the audit.

## What changed

- preserve repeated operations instead of overwriting earlier steps when the same operation type is chained multiple times
- execute repeated serialized operations in insertion order during processing
- preserve variant `url` values when rebuilding collections from serialized arrays
- append the target extension for converted variants when the source filename/path has no extension
- install `imagick` in CI so the Imagick-specific tests run instead of being skipped
- document the repeated-operation serialization shape in the README, processing docs, and changelog

## Release impact

This keeps the existing single-operation serialization shape intact, while extending the on-disk format for repeated operations to an ordered list only when the same operation appears more than once.
