### PR TITLE
Backport v1 maintenance fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        extensions: mbstring, json, fileinfo
+        extensions: mbstring, json, fileinfo, imagick
         tools: pecl
         coverage: pcov
 
@@ -56,7 +56,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.1'
-        extensions: mbstring, json, fileinfo
+        extensions: mbstring, json, fileinfo, imagick
         coverage: none
         tools: pecl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - TBD
+## [1.0.1] - TBD
+
+### Fixed
+- Repeating the same operation type on a variant no longer overwrites the earlier step. Repeated operations are preserved and executed in insertion order
+- `ImageVariantCollection::fromArray()` now preserves serialized variant URLs in addition to paths and operations
+- CI now installs `imagick`, and the test suite includes an Imagick-driver processing smoke test so both supported drivers are exercised
+
+## [1.0.0] - 2025-11-10
 
 ### Added
 - Added `scale()` method to `ImageVariant` for resizing while preserving aspect ratio

--- a/docs/Processing-Images.md
+++ b/docs/Processing-Images.md
@@ -67,6 +67,15 @@ $collection->addNew('resizeAndFlip')
 $collection->addNew('crop')
     ->crop(100, 100);
 
+// Repeating the same operation type keeps both steps in order
+$collection->addNew('effects')
+    ->callback(function ($image, $args) {
+        // first pass
+    })
+    ->callback(function ($image, $args) {
+        // second pass
+    });
+
 $file = $file->withVariants($collection->toArray());
 
 // Process ALL variants (default behavior - empty array processes everything)
@@ -82,3 +91,22 @@ $file = $imageProcessor
 // OR: Skip the filter entirely to process all
 // $file = $imageProcessor->process($file);
 ```
+
+## Variant serialization
+
+`ImageVariantCollection::toArray()` preserves operation order, including repeated operations of the same name. Single operations keep the legacy shape:
+
+```php
+'resize' => ['width' => 300, 'height' => 300]
+```
+
+If the same operation is added more than once, that entry becomes a list:
+
+```php
+'callback' => [
+    ['callback' => $first],
+    ['callback' => $second],
+]
+```
+
+`ImageVariantCollection::fromArray()` accepts both shapes and rebuilds the variant chain in the same order, while preserving serialized `path` and `url` values.

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Built on top of [Intervention Image v3](https://image.intervention.io/v3).
  * Supports multiple image operations: resize, scale, crop, rotate, flip, sharpen, and more
  * Optimizes image file size using [spatie/image-optimizer](https://github.com/spatie/image-optimizer)
  * Works with League Flysystem for flexible storage backends
- * Fluent API for chaining image operations
+ * Fluent API for chaining image operations, including repeating the same operation type multiple times
 
 ## Requirements
 
@@ -44,9 +44,20 @@ $collection->addNew('avatar')
     ->cover(150, 150)
     ->optimize();
 
+// Repeating the same operation type preserves both steps
+$collection->addNew('effects')
+    ->callback(function ($image, $args) {
+        // first pass
+    })
+    ->callback(function ($image, $args) {
+        // second pass
+    });
+
 $file = $file->withVariants($collection->toArray());
 $file = $imageProcessor->process($file);
 ```
+
+Repeated operations of the same name are preserved in order when you serialize variants with `toArray()` and rebuild them later with `ImageVariantCollection::fromArray()`.
 
 ## Documentation
 

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -25,6 +25,7 @@ use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\TempFileCreat
 use PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface;
 use PhpCollective\Infrastructure\Storage\UrlBuilder\UrlBuilderInterface;
 use PhpCollective\Infrastructure\Storage\Utility\TemporaryFile;
+use function is_array;
 use function PhpCollective\Infrastructure\Storage\openFile;
 
 /**
@@ -251,7 +252,9 @@ class ImageProcessor implements ProcessorInterface
 
             // Apply the operations
             foreach ($data['operations'] as $operation => $arguments) {
-                $operations->{$operation}($arguments);
+                foreach ($this->normalizeOperationPayloads($arguments) as $payload) {
+                    $operations->{$operation}($payload);
+                }
             }
 
             $path = $this->pathBuilder->pathForVariant($file, $variant);
@@ -280,6 +283,26 @@ class ImageProcessor implements ProcessorInterface
         unlink($tempFile);
 
         return $file;
+    }
+
+    /**
+     * @param mixed $arguments Serialized operation payload for one method
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function normalizeOperationPayloads(mixed $arguments): array
+    {
+        if (!is_array($arguments)) {
+            return [[]];
+        }
+        if ($arguments === []) {
+            return [[]];
+        }
+        if (array_is_list($arguments) && is_array($arguments[0] ?? null)) {
+            return $arguments;
+        }
+
+        return [$arguments];
     }
 
     /**

--- a/src/ImageVariant.php
+++ b/src/ImageVariant.php
@@ -25,7 +25,18 @@ class ImageVariant extends Variant
     protected string $name;
 
     /**
-     * @var array<string, array<string, mixed>>
+     * Single operations keep the legacy shape:
+     *
+     *     'resize' => ['width' => 300, 'height' => 300]
+     *
+     * Repeated operations of the same name are stored as a list:
+     *
+     *     'callback' => [
+     *         ['callback' => $first],
+     *         ['callback' => $second],
+     *     ]
+     *
+     * @var array<string, array<string, mixed>|array<int, array<string, mixed>>>
      */
     protected array $operations;
 
@@ -80,12 +91,12 @@ class ImageVariant extends Variant
      */
     public function crop(int $width, int $height, ?int $x = null, ?int $y = null)
     {
-        $this->operations['crop'] = [
+        $this->appendOperation('crop', [
             'width' => $width,
             'height' => $height,
             'x' => $x,
             'y' => $y,
-        ];
+        ]);
 
         return $this;
     }
@@ -97,9 +108,9 @@ class ImageVariant extends Variant
      */
     public function sharpen(int $amount)
     {
-        $this->operations['sharpen'] = [
+        $this->appendOperation('sharpen', [
             'amount' => $amount,
-        ];
+        ]);
 
         return $this;
     }
@@ -111,9 +122,9 @@ class ImageVariant extends Variant
      */
     public function rotate(int $angle)
     {
-        $this->operations['rotate'] = [
+        $this->appendOperation('rotate', [
             'angle' => $angle,
-        ];
+        ]);
 
         return $this;
     }
@@ -126,10 +137,10 @@ class ImageVariant extends Variant
      */
     public function heighten(int $height, bool $preventUpscale = false)
     {
-        $this->operations['heighten'] = [
+        $this->appendOperation('heighten', [
             'height' => $height,
             'preventUpscale' => $preventUpscale,
-        ];
+        ]);
 
         return $this;
     }
@@ -142,10 +153,10 @@ class ImageVariant extends Variant
      */
     public function widen(int $width, bool $preventUpscale = false)
     {
-        $this->operations['widen'] = [
+        $this->appendOperation('widen', [
             'width' => $width,
             'preventUpscale' => $preventUpscale,
-        ];
+        ]);
 
         return $this;
     }
@@ -161,11 +172,11 @@ class ImageVariant extends Variant
      */
     public function resize(int $width, int $height, bool $preventUpscale = false)
     {
-        $this->operations['resize'] = [
+        $this->appendOperation('resize', [
             'width' => $width,
             'height' => $height,
             'preventUpscale' => $preventUpscale,
-        ];
+        ]);
 
         return $this;
     }
@@ -181,11 +192,11 @@ class ImageVariant extends Variant
      */
     public function scale(int $width, int $height, bool $preventUpscale = false)
     {
-        $this->operations['scale'] = [
+        $this->appendOperation('scale', [
             'width' => $width,
             'height' => $height,
             'preventUpscale' => $preventUpscale,
-        ];
+        ]);
 
         return $this;
     }
@@ -197,9 +208,9 @@ class ImageVariant extends Variant
      */
     public function flipHorizontal()
     {
-        $this->operations['flipHorizontal'] = [
+        $this->appendOperation('flipHorizontal', [
             'direction' => self::FLIP_HORIZONTAL,
-        ];
+        ]);
 
         return $this;
     }
@@ -211,9 +222,9 @@ class ImageVariant extends Variant
      */
     public function flipVertical()
     {
-        $this->operations['flipVertical'] = [
+        $this->appendOperation('flipVertical', [
             'direction' => self::FLIP_VERTICAL,
-        ];
+        ]);
 
         return $this;
     }
@@ -236,9 +247,9 @@ class ImageVariant extends Variant
             ));
         }
 
-        $this->operations['flip'] = [
+        $this->appendOperation('flip', [
             'direction' => $direction,
-        ];
+        ]);
 
         return $this;
     }
@@ -253,9 +264,9 @@ class ImageVariant extends Variant
      */
     public function callback(callable $callback)
     {
-        $this->operations['callback'] = [
+        $this->appendOperation('callback', [
             'callback' => $callback,
-        ];
+        ]);
 
         return $this;
     }
@@ -276,15 +287,54 @@ class ImageVariant extends Variant
         bool $preventUpscale = false,
         string $position = 'center',
     ) {
-        $this->operations['cover'] = [
+        $this->appendOperation('cover', [
             'width' => $width,
             'height' => $height,
             'callback' => $callback,
             'preventUpscale' => $preventUpscale,
             'position' => $position,
-        ];
+        ]);
 
         return $this;
+    }
+
+    /**
+     * @param string $name Operation name
+     * @param array<string, mixed> $payload Serialized operation payload
+     *
+     * @return void
+     */
+    protected function appendOperation(string $name, array $payload): void
+    {
+        if (!isset($this->operations[$name])) {
+            $this->operations[$name] = $payload;
+
+            return;
+        }
+
+        $existing = $this->operations[$name];
+        if ($this->isOperationSequence($existing)) {
+            $existing[] = $payload;
+            $this->operations[$name] = $existing;
+
+            return;
+        }
+
+        $this->operations[$name] = [$existing, $payload];
+    }
+
+    /**
+     * @param array<string, mixed>|array<int, array<string, mixed>> $value Serialized operation entry
+     *
+     * @return bool
+     */
+    protected function isOperationSequence(array $value): bool
+    {
+        if ($value === []) {
+            return false;
+        }
+
+        return array_is_list($value) && is_array($value[0] ?? null);
     }
 
     /**

--- a/src/ImageVariantCollection.php
+++ b/src/ImageVariantCollection.php
@@ -19,6 +19,7 @@ use Iterator;
 use PhpCollective\Infrastructure\Storage\Processor\Exception\VariantExistsException;
 use PhpCollective\Infrastructure\Storage\Processor\Image\Exception\UnsupportedOperationException;
 use ReflectionClass;
+use function is_array;
 
 /**
  * Conversion Collection
@@ -82,26 +83,51 @@ class ImageVariantCollection implements ImageVariantCollectionInterface
             if (!empty($data['path']) && is_string($data['path'])) {
                 $variant = $variant->withPath($data['path']);
             }
+            if (!empty($data['url']) && is_string($data['url'])) {
+                $variant = $variant->withUrl($data['url']);
+            }
 
             foreach ($data['operations'] as $method => $args) {
                 if (!method_exists($variant, $method)) {
                     UnsupportedOperationException::withName($method);
                 }
 
-                /** @var array<mixed> $parameters */
-                $parameters = self::filterArgs($variant, $method, $args);
-                /** @var callable $callable */
-                $callable = [$variant, $method];
-                $variant = call_user_func_array(
-                    $callable,
-                    $parameters,
-                );
+                foreach (self::normalizeOperationPayloads($args) as $payload) {
+                    /** @var array<mixed> $parameters */
+                    $parameters = self::filterArgs($variant, $method, $payload);
+                    /** @var callable $callable */
+                    $callable = [$variant, $method];
+                    $variant = call_user_func_array(
+                        $callable,
+                        $parameters,
+                    );
+                }
             }
 
             $that->add($variant);
         }
 
         return $that;
+    }
+
+    /**
+     * @param mixed $args Serialized operation payload for one method
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected static function normalizeOperationPayloads(mixed $args): array
+    {
+        if (!is_array($args)) {
+            return [[]];
+        }
+        if ($args === []) {
+            return [[]];
+        }
+        if (array_is_list($args) && is_array($args[0] ?? null)) {
+            return $args;
+        }
+
+        return [$args];
     }
 
     /**

--- a/tests/TestCase/Processor/Image/ImageProcessorTest.php
+++ b/tests/TestCase/Processor/Image/ImageProcessorTest.php
@@ -15,6 +15,7 @@
 namespace PhpCollective\Test\TestCase\Processor\Image;
 
 use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
 use PhpCollective\Infrastructure\Storage\File;
 use PhpCollective\Infrastructure\Storage\FileFactory;
@@ -34,8 +35,7 @@ class ImageProcessorTest extends TestCase
      */
     public function testProcessor(): void
     {
-        $fileStorage = $this->getMockBuilder(FileStorageInterface::class)
-            ->getMock();
+        $fileStorage = $this->createStub(FileStorageInterface::class);
 
         $pathBuilder = new PathBuilder();
 
@@ -64,6 +64,78 @@ class ImageProcessorTest extends TestCase
 
         $file = $file->withVariants($collection->toArray());
 
+        $file = $processor->process($file);
+
+        $this->assertInstanceOf(File::class, $file);
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessorAppliesRepeatedOperationsInOrder(): void
+    {
+        $applied = [];
+        $fileStorage = $this->createStub(FileStorageInterface::class);
+
+        $processor = new ImageProcessor(
+            $fileStorage,
+            new PathBuilder(),
+            new ImageManager(new Driver()),
+        );
+
+        $file = FileFactory::fromDisk($this->getFixtureFile('titus.jpg'), 'local')
+            ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973')
+            ->withFilename('foobar.jpg')
+            ->addToCollection('avatar')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $collection
+            ->addNew('effects')
+            ->callback(function ($image, $args) use (&$applied): void {
+                $applied[] = 'first';
+            })
+            ->callback(function ($image, $args) use (&$applied): void {
+                $applied[] = 'second';
+            });
+
+        $file = $file->withVariants($collection->toArray());
+        $processor->process($file);
+
+        $this->assertSame(['first', 'second'], $applied);
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessorWithImagickDriver(): void
+    {
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped('Imagick driver requires the Imagick PHP extension');
+        }
+
+        $fileStorage = $this->createStub(FileStorageInterface::class);
+
+        $processor = new ImageProcessor(
+            $fileStorage,
+            new PathBuilder(),
+            new ImageManager(new ImagickDriver()),
+        );
+
+        $file = FileFactory::fromDisk($this->getFixtureFile('titus.jpg'), 'local')
+            ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973')
+            ->withFilename('foobar.jpg')
+            ->addToCollection('avatar')
+            ->belongsToModel('User', '1');
+
+        $collection = ImageVariantCollection::create();
+        $collection
+            ->addNew('resizeAndFlip')
+            ->flipHorizontal()
+            ->resize(300, 300)
+            ->optimize();
+
+        $file = $file->withVariants($collection->toArray());
         $file = $processor->process($file);
 
         $this->assertInstanceOf(File::class, $file);

--- a/tests/TestCase/Processor/Image/ImageVariantCollectionTest.php
+++ b/tests/TestCase/Processor/Image/ImageVariantCollectionTest.php
@@ -95,4 +95,38 @@ class ImageVariantCollectionTest extends TestCase
         $result = json_encode($collection);
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @return void
+     */
+    public function testFromArrayPreservesUrlAndRepeatedOperations(): void
+    {
+        $first = static function ($image, $args): void {
+        };
+        $second = static function ($image, $args): void {
+        };
+
+        $expected = [
+            'effects' => [
+                'operations' => [
+                    'callback' => [
+                        ['callback' => $first],
+                        ['callback' => $second],
+                    ],
+                ],
+                'path' => '/variants/effects.jpg',
+                'url' => 'https://cdn.example.test/variants/effects.jpg',
+                'optimize' => false,
+            ],
+        ];
+
+        $collection = ImageVariantCollection::fromArray($expected);
+        $result = $collection->toArray();
+
+        $this->assertSame('/variants/effects.jpg', $result['effects']['path']);
+        $this->assertSame('https://cdn.example.test/variants/effects.jpg', $result['effects']['url']);
+        $this->assertCount(2, $result['effects']['operations']['callback']);
+        $this->assertSame($first, $result['effects']['operations']['callback'][0]['callback']);
+        $this->assertSame($second, $result['effects']['operations']['callback'][1]['callback']);
+    }
 }

--- a/tests/TestCase/Processor/Image/ImageVariantTest.php
+++ b/tests/TestCase/Processor/Image/ImageVariantTest.php
@@ -99,4 +99,25 @@ class ImageVariantTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @return void
+     */
+    public function testVariantPreservesRepeatedOperations(): void
+    {
+        $first = static function ($image, $args): void {
+        };
+        $second = static function ($image, $args): void {
+        };
+
+        $variant = ImageVariant::create('effects')
+            ->callback($first)
+            ->callback($second);
+
+        $result = $variant->toArray();
+
+        $this->assertCount(2, $result['operations']['callback']);
+        $this->assertSame($first, $result['operations']['callback'][0]['callback']);
+        $this->assertSame($second, $result['operations']['callback'][1]['callback']);
+    }
 }


### PR DESCRIPTION
## Summary

Backports the v1-applicable release-health fixes from the 2.0 audit onto the `v1` maintenance line.

## What changed

- preserve repeated operations instead of overwriting earlier steps when the same operation type is chained multiple times
- execute repeated serialized operations in insertion order during processing
- preserve variant `url` values when rebuilding collections from serialized arrays
- install `imagick` in CI and add an Imagick-driver processing smoke test so both supported drivers are exercised
- document the repeated-operation serialization shape in the README, processing docs, and changelog

## Not included

- no `convert()` backport: v1 does not have a `convert` operation, so the extensionless-convert bug does not exist on this line
